### PR TITLE
Fix filtered fetching and citation network; resolve out-of-corpus citations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ data/
 temp_repo/
 
 .vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -100,12 +100,56 @@ Retrieves both metadata and full-text content for ECHR cases.
 
 Generates nodes and edges for citation network analysis from case metadata.
 
+The network is **self-enclosed by default**: edges only point at documents
+present in the corpus you pass in. Citations to cases outside the corpus are
+returned (and saved) as a missing-references table with one row per citing
+document and unresolved reference, including the parsed application numbers,
+casename, year, and language — so out-of-corpus citations are never silently
+lost and can be resolved later.
+
 **Parameters:**
 - `metadata_path` (str, optional): Path to metadata CSV file
 - `df` (DataFrame, optional): Metadata DataFrame (use one of these two)
 - `save_file` (str, default: 'y'): Save to files ('y') or return objects ('n')
+- `resolve_external` (bool, default: False): Resolve references that point
+  outside the corpus by querying HUDOC (batched lookups). Resolved targets are
+  added to the edges and their metadata is appended to the nodes with
+  `in_corpus=False`
+- `reference_df` (DataFrame, optional): Resolve external references offline
+  against this larger metadata DataFrame instead of querying HUDOC (composes
+  with `resolve_external`: offline first, HUDOC for the remainder)
 
 **Returns:** Tuple of (nodes DataFrame, edges DataFrame, missing references DataFrame)
+
+### `get_document_citations()` - Out-Citations of a Single Document
+
+Parses one document's complete citation list (its `scl` field) and resolves
+each cited case to a real HUDOC document.
+
+**Parameters:**
+- `itemid` (str, optional): HUDOC itemid; metadata is fetched automatically
+- `document` (dict/Series, optional): In-memory document with an `scl` field
+- `resolve` (bool, default: True): Resolve citations against HUDOC
+- `reference_df` (DataFrame, optional): Resolve offline against this corpus
+
+**Returns:** DataFrame with one row per citation. Resolved rows carry
+`resolved_id`, `resolved_itemid`, `resolved_docname`, and `match_method`
+(`appno` or `casename`); unresolvable references are kept with empty
+resolution columns, never dropped.
+
+### `resolve_references()` / `parse_scl_references()` - Lower-Level Building Blocks
+
+For custom pipelines, the pieces behind the two functions above are exported
+directly:
+
+- `parse_scl_references(scl, citing_id=None)` turns a raw `scl` citation
+  string into a DataFrame with one row per reference (parsed application
+  numbers, casename, year, language)
+- `resolve_references(missing_df, reference_df=None)` resolves any such table
+  (including the missing-references output of `get_nodes_edges()`) and returns
+  `(resolved, external_nodes, still_missing)`. With `reference_df` it works
+  fully offline; without it, HUDOC is queried in batches. References are tried
+  by application number first, then by casename
 
 ### `get_echr_segments()` - Segment Full Texts
 
@@ -229,6 +273,52 @@ print(f"Missing references: {len(missing)} unresolved citations")
 # - data/ECHR_edges.csv (citation relationships)
 # - data/ECHR_nodes.json (JSON format)
 # - data/ECHR_edges.json (JSON format)
+# - data/ECHR_missing_references.csv (citations pointing outside the corpus,
+#   with parsed appnos/casename/year/language)
+```
+
+The network is self-enclosed: edges only connect documents inside your fetch.
+To also link citations that point *outside* the corpus, resolve them against
+HUDOC (or against a larger offline corpus):
+
+```python
+from echr_extractor import get_echr, get_nodes_edges
+
+df = get_echr(start_date='2022-01-10', end_date='2022-01-20', save_file='n')
+
+# Resolve out-of-corpus citations with batched HUDOC lookups
+nodes, edges, missing = get_nodes_edges(df=df, save_file='n',
+                                        resolve_external=True)
+
+external = nodes[~nodes['in_corpus']]
+print(f"{len(external)} cited cases fetched from outside the corpus")
+print(f"{len(missing)} references could not be resolved at all")
+
+# Offline alternative: resolve against metadata you already downloaded
+# nodes, edges, missing = get_nodes_edges(df=df, reference_df=full_corpus_df)
+```
+
+### Example 5b: Out-Citations of a Single Document
+
+```python
+from echr_extractor import get_document_citations
+
+# Everything Sanoma Uitgevers B.V. v. the Netherlands [GC] cites
+citations = get_document_citations(itemid='001-100448')
+
+resolved = citations[citations['resolved_id'].notna()]
+print(f"{len(resolved)} of {len(citations)} citations resolved")
+print(resolved[['missing_references', 'resolved_docname', 'match_method']].head())
+
+# Works on in-memory documents too (e.g. a row from get_echr output):
+# citations = get_document_citations(document=df.iloc[0])
+```
+
+Or from the command line:
+
+```bash
+echr-extractor citations --itemid 001-100448
+# -> data/echr_citations_001-100448.csv
 ```
 
 ### Example 6: Segment Full Texts into Legal Sections
@@ -366,6 +456,12 @@ echr-extractor extract-full --count 50 --language ENG --threads 10
 # Generate network data (file names include the fetched range)
 echr-extractor network --metadata-path data/echr_metadata_0-100_dates_START-END.csv
 
+# Same, but also resolve citations pointing outside the corpus via HUDOC
+echr-extractor network --metadata-path data/echr_metadata_0-100_dates_START-END.csv --resolve-external
+
+# List and resolve the out-citations of a single document
+echr-extractor citations --itemid 001-100448
+
 # Segment full texts into legal sections
 echr-extractor segment \
   --metadata-path data/echr_metadata_0-100_dates_START-END.csv \
@@ -385,7 +481,9 @@ When `save_file='y'` (default), the library creates a `data/` directory with:
 - `echr_full_text_*.json` - Full case texts (when using `get_echr_extra`)
 - `ECHR_nodes.csv` - Network nodes (when using `get_nodes_edges`)
 - `ECHR_edges.csv` - Network edges (when using `get_nodes_edges`)
-- `ECHR_missing_references.csv` - Unresolved citations (when using `get_nodes_edges`)
+- `ECHR_missing_references.csv` - Unresolved citations with parsed appnos/casename/year/language (when using `get_nodes_edges`)
+- `ECHR_resolved_references.csv` - Externally resolved citations (when using `resolve_external` or `reference_df`)
+- `echr_citations_<itemid>.csv` - Out-citations of one document (when using the `citations` CLI command)
 - `ECHR_segments.csv` - Segmented legal sections (when using `get_echr_segments`)
 
 ## Performance Tips

--- a/README.md
+++ b/README.md
@@ -263,9 +263,11 @@ import json
 import pandas as pd
 from echr_extractor import get_echr_segments
 
-# Load previously saved data
-df = pd.read_csv('data/echr_metadata.csv')
-with open('data/echr_full_text.json') as f:
+# Load previously saved data. Saved file names include the fetched
+# range, e.g. echr_metadata_0-100_dates_START-END.csv and
+# echr_full_text_0-100_dates_START-END.json
+df = pd.read_csv('data/echr_metadata_0-100_dates_START-END.csv')
+with open('data/echr_full_text_0-100_dates_START-END.json') as f:
     full_texts = json.load(f)
 
 # Segment with custom settings
@@ -295,9 +297,11 @@ df = get_echr(
 
 print(f"Found {len(df)} cases about Article 8")
 
-# Search for multiple conditions
+# Search for multiple conditions. Note: the 'violation' field contains
+# the numbers of the violated articles (not YES/NO), so filter for a
+# violation of those same articles:
 df = get_echr(
-    query_payload='article:(8 OR 10) AND violation:YES',
+    query_payload='article:(8 OR 10) AND (violation:8 OR violation:10)',
     language=['ENG']
 )
 ```
@@ -359,13 +363,13 @@ echr-extractor extract --count 100 --language ENG --verbose
 # Extract metadata and full text
 echr-extractor extract-full --count 50 --language ENG --threads 10
 
-# Generate network data
-echr-extractor network --metadata-path data/echr_metadata.csv
+# Generate network data (file names include the fetched range)
+echr-extractor network --metadata-path data/echr_metadata_0-100_dates_START-END.csv
 
 # Segment full texts into legal sections
 echr-extractor segment \
-  --metadata-path data/echr_metadata.csv \
-  --fulltext-path data/echr_full_text.json \
+  --metadata-path data/echr_metadata_0-100_dates_START-END.csv \
+  --fulltext-path data/echr_full_text_0-100_dates_START-END.json \
   --allowed-langs ENG FRE \
   --min-segment-length 50
 
@@ -377,8 +381,8 @@ echr-extractor --help
 
 When `save_file='y'` (default), the library creates a `data/` directory with:
 
-- `ECHR_metadata_*.csv` - Case metadata
-- `ECHR_full_text_*.json` - Full case texts (when using `get_echr_extra`)
+- `echr_metadata_*.csv` - Case metadata (name includes the fetched index/date range)
+- `echr_full_text_*.json` - Full case texts (when using `get_echr_extra`)
 - `ECHR_nodes.csv` - Network nodes (when using `get_nodes_edges`)
 - `ECHR_edges.csv` - Network edges (when using `get_nodes_edges`)
 - `ECHR_missing_references.csv` - Unresolved citations (when using `get_nodes_edges`)

--- a/src/echr_extractor/ECHR_html_downloader.py
+++ b/src/echr_extractor/ECHR_html_downloader.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import threading
 
@@ -98,7 +99,9 @@ def download_full_text_separate(item_ids, eclis, dict_list):
             item_id = item_ids[i]
             ecli = eclis[i]
             try:
-                r = requests.get(base_url + item_id, timeout=1)
+                r = requests.get(base_url + item_id, timeout=10)
+                # An error page must not be stored as the document text
+                r.raise_for_status()
                 json_dict = {
                     "item_id": item_id,
                     "ecli": ecli,
@@ -111,5 +114,16 @@ def download_full_text_separate(item_ids, eclis, dict_list):
         return retry_ids, retry_eclis
 
     retry_ids, retry_eclis = download_html(item_ids, eclis)
-    download_html(retry_ids, retry_eclis)
+    failed_ids, _ = download_html(retry_ids, retry_eclis)
+    if failed_ids:
+        logging.warning(
+            f"Full text could not be downloaded for {len(failed_ids)} "
+            f"document(s): {failed_ids}"
+        )
+    empty_ids = [d["item_id"] for d in full_list if not d["full_text"]]
+    if empty_ids:
+        logging.warning(
+            f"No HTML text available (kept with empty full_text) for "
+            f"{len(empty_ids)} document(s): {empty_ids}"
+        )
     dict_list.append(full_list)

--- a/src/echr_extractor/ECHR_metadata_harvester.py
+++ b/src/echr_extractor/ECHR_metadata_harvester.py
@@ -79,7 +79,9 @@ def get_date_ranges(start_date, end_date, days_per_batch=365):
     date_ranges = []
     current_start = start_dt
 
-    while current_start < end_dt:
+    # <= so a remainder of exactly one day (or a single-day range) still
+    # produces a batch instead of being silently dropped.
+    while current_start <= end_dt:
         current_end = min(current_start + timedelta(days=days_per_batch - 1), end_dt)
         date_ranges.append(
             (current_start.strftime("%Y-%m-%d"), current_end.strftime("%Y-%m-%d"))
@@ -87,6 +89,36 @@ def get_date_ranges(start_date, end_date, days_per_batch=365):
         current_start = current_end + timedelta(days=1)
 
     return date_ranges
+
+
+# HUDOC's search backend refuses to page past this many results within a
+# single query: any request with start+length above it returns zero rows.
+# Larger result sets must be partitioned into date windows.
+HUDOC_MAX_RESULTS_PER_QUERY = 10000
+
+
+def split_date_range(start_date, end_date):
+    """Bisect a date range into two halves for query partitioning.
+
+    Open ends default to 1900-01-01 / today. Returns a list of two
+    (start, end) tuples, or None when the range is a single day and
+    cannot be split further.
+    """
+    start_dt = datetime.strptime(start_date or "1900-01-01", "%Y-%m-%d")
+    end_str = end_date or datetime.today().date().strftime("%Y-%m-%d")
+    end_dt = datetime.strptime(end_str, "%Y-%m-%d")
+
+    if start_dt >= end_dt:
+        return None
+
+    mid_dt = start_dt + (end_dt - start_dt) / 2
+    return [
+        (start_dt.strftime("%Y-%m-%d"), mid_dt.strftime("%Y-%m-%d")),
+        (
+            (mid_dt + timedelta(days=1)).strftime("%Y-%m-%d"),
+            end_dt.strftime("%Y-%m-%d"),
+        ),
+    ]
 
 
 def basic_function(term, values):
@@ -248,8 +280,15 @@ def link_to_query(link):
             vals = link_dictionary.get(key)
             funct = query_map.get(key)
             if funct is None:
-                print(f"Skipping unsupported query key: {key}")
-                continue
+                # Keys not in query_map (e.g. article, respondent, violation)
+                # are still valid HUDOC field filters; fall back to the basic
+                # (key="value") form so the filter is applied rather than
+                # silently dropped.
+                logging.warning(
+                    f"Query key '{key}' not explicitly mapped, "
+                    "applying basic field filter"
+                )
+                funct = basic_function
             query_elements.append(funct(key, vals))
     if date_addition:
         query_elements.append(date_addition)
@@ -274,6 +313,7 @@ def determine_meta_url(link, query_payload, start_date, end_date):
         META_URL = (
             "http://hudoc.echr.coe.int/app/query/results"
             "?query=(contentsitename=ECHR) AND "
+            "(NOT (doctype=PR OR doctype=HFCOMOLD OR doctype=HECOMOLD)) AND "
             '(documentcollectionid2:"JUDGMENTS" OR '
             'documentcollectionid2:"COMMUNICATEDCASES" OR '
             'documentcollectionid2:"DECISIONS" OR '
@@ -430,10 +470,21 @@ def get_echr_metadata(
     total_processed = 0
     total_failed = 0
 
-    for batch_idx, (batch_start_date, batch_end_date) in enumerate(date_ranges):
+    # Queries whose result set exceeds HUDOC's pagination cap must be
+    # partitioned by date; link/query_payload queries cannot be safely
+    # rewritten, so those can only warn.
+    can_partition = not link and not query_payload
+    pending_ranges = list(date_ranges)
+    batch_idx = 0
+    first_fetch = True
+
+    while pending_ranges:
+        batch_start_date, batch_end_date = pending_ranges.pop(0)
         if verbose:
             logging.info(
-                f"Processing date batch {batch_idx + 1}/{len(date_ranges)}: {batch_start_date} to {batch_end_date}"
+                f"Processing date batch {batch_idx + 1} "
+                f"({len(pending_ranges)} pending): "
+                f"{batch_start_date} to {batch_end_date}"
             )
 
         # Determine meta URL for this batch
@@ -462,6 +513,7 @@ def get_echr_metadata(
         if r is None:
             logging.error(f"Failed to get result count for batch {batch_idx + 1}")
             total_failed += 1
+            batch_idx += 1
             continue
 
         try:
@@ -471,16 +523,56 @@ def get_echr_metadata(
         except (KeyError, ValueError) as e:
             logging.error(f"Failed to parse result count: {e}")
             total_failed += 1
+            batch_idx += 1
             continue
 
         if resultcount == 0:
             if verbose:
                 logging.info(f"No results found for batch {batch_idx + 1}")
+            batch_idx += 1
             continue
 
-        # Determine actual end_id for this batch
-        batch_end_id = min(end_id, resultcount) if end_id else resultcount
-        batch_start_id = start_id if batch_idx == 0 else 0
+        # HUDOC refuses to page past HUDOC_MAX_RESULTS_PER_QUERY within a
+        # single query, so a window with more results than that must be
+        # bisected into smaller date windows (requests beyond the cap
+        # would silently return zero rows).
+        if resultcount > HUDOC_MAX_RESULTS_PER_QUERY:
+            halves = (
+                split_date_range(batch_start_date, batch_end_date)
+                if can_partition
+                else None
+            )
+            if halves:
+                if verbose:
+                    logging.info(
+                        f"{resultcount} results exceed the HUDOC limit of "
+                        f"{HUDOC_MAX_RESULTS_PER_QUERY} per query; splitting "
+                        f"window into {halves[0]} and {halves[1]}"
+                    )
+                pending_ranges = halves + pending_ranges
+                continue
+            logging.warning(
+                f"HUDOC returns at most {HUDOC_MAX_RESULTS_PER_QUERY} "
+                f"results per query but {resultcount} match; only the "
+                f"first {HUDOC_MAX_RESULTS_PER_QUERY} can be fetched. "
+                "Narrow the query (e.g. add kpdate bounds) to retrieve "
+                "the rest."
+            )
+            resultcount = HUDOC_MAX_RESULTS_PER_QUERY
+
+        # Determine actual end_id for this batch. end_id caps the TOTAL
+        # number of records across all date batches, not per batch —
+        # otherwise count=N over a multi-batch date range would fetch up
+        # to N records per batch.
+        batch_start_id = start_id if first_fetch else 0
+        first_fetch = False
+        if end_id:
+            remaining = (end_id - start_id) - total_processed
+            if remaining <= 0:
+                break
+            batch_end_id = min(resultcount, batch_start_id + remaining)
+        else:
+            batch_end_id = resultcount
 
         if verbose:
             msg = f"Fetching {batch_end_id - batch_start_id} results from index {batch_start_id} to {batch_end_id}"
@@ -497,7 +589,7 @@ def get_echr_metadata(
         if progress_bar and (batch_end_id - batch_start_id) > batch_size:
             pbar = tqdm(
                 total=batch_end_id - batch_start_id,
-                desc=f"Batch {batch_idx + 1}/{len(date_ranges)}",
+                desc=f"Batch {batch_idx + 1}",
                 unit="records",
                 leave=False,
             )
@@ -549,6 +641,7 @@ def get_echr_metadata(
             logging.info(
                 f"Batch {batch_idx + 1} completed: {batch_processed} processed, {batch_failed} failed"
             )
+        batch_idx += 1
 
     # Final summary
     if verbose:

--- a/src/echr_extractor/ECHR_nodes_edges_list_transform.py
+++ b/src/echr_extractor/ECHR_nodes_edges_list_transform.py
@@ -8,6 +8,15 @@ from tqdm import tqdm
 
 from .clean_ref import clean_pattern
 
+MISSING_REFERENCE_COLUMNS = [
+    "citing_id",
+    "missing_references",
+    "extracted_appnos",
+    "casename",
+    "year",
+    "ref_language",
+]
+
 
 @lru_cache(maxsize=200000)
 def parse_date_cached(text):
@@ -167,6 +176,7 @@ def retrieve_edges_list(df, df_unfiltered):
         leave=True,
     ):
         eclis = set()
+        citing_id = node_identifier(item.ecli, getattr(item, "itemid", None))
 
         if pd.notna(item.scl):
             ref_list = str(item.scl).split(";")
@@ -285,11 +295,19 @@ def retrieve_edges_list(df, df_unfiltered):
                     eclis.update(final_candidates)
                 else:
                     count += 1
-                    missing_cases.append(ref)
+                    missing_cases.append(
+                        {
+                            "citing_id": citing_id,
+                            "missing_references": ref,
+                            "extracted_appnos": ";".join(app_numbers),
+                            "casename": str(get_casename(ref) or "").strip(),
+                            "year": year_from_ref if year_from_ref > 0 else None,
+                            "ref_language": ref_lang,
+                        }
+                    )
 
             # Add edges for this case, keyed by ECLI or itemid fallback.
             # A case must not reference itself (original behavior).
-            citing_id = node_identifier(item.ecli, getattr(item, "itemid", None))
             eclis.discard(citing_id)
             if eclis and citing_id:
                 edges_list.append({"ecli": citing_id, "references": list(eclis)})
@@ -305,9 +323,17 @@ def retrieve_edges_list(df, df_unfiltered):
     else:
         edges = pd.DataFrame(columns=["ecli", "references"])
 
-    missing_cases_set = set(missing_cases)
-    missing_cases = list(missing_cases_set)
-    missing_df = pd.DataFrame({"missing_references": missing_cases})
+    # One row per (citing document, unresolved reference), with the
+    # parsed components so callers can distinguish out-of-corpus
+    # citations from unparseable ones and resolve them later.
+    if missing_cases:
+        missing_df = (
+            pd.DataFrame(missing_cases)
+            .drop_duplicates(subset=["citing_id", "missing_references"])
+            .reset_index(drop=True)
+        )
+    else:
+        missing_df = pd.DataFrame(columns=MISSING_REFERENCE_COLUMNS)
 
     return edges, missing_df
 

--- a/src/echr_extractor/ECHR_nodes_edges_list_transform.py
+++ b/src/echr_extractor/ECHR_nodes_edges_list_transform.py
@@ -1,11 +1,27 @@
 import logging
 import re
+from functools import lru_cache
 
 import dateparser
 import pandas as pd
 from tqdm import tqdm
 
 from .clean_ref import clean_pattern
+
+
+@lru_cache(maxsize=200000)
+def parse_date_cached(text):
+    """Memoized dateparser.parse for citation/judgment date strings.
+
+    dateparser.parse dominates the edge-calculation runtime (~4ms per
+    call, scanning ~190 locales), and the same date strings recur across
+    thousands of citations. Case names and dates only appear in English
+    or French, so the locale scan is restricted accordingly. Strings
+    without a digit can never parse as a date and are skipped outright.
+    """
+    if not any(ch.isdigit() for ch in text):
+        return None
+    return dateparser.parse(text, languages=["en", "fr"])
 
 
 def open_metadata(PATH_metadata):
@@ -51,6 +67,21 @@ def get_language_from_metadata(df):
     df.to_json("langisocode-nodes.json", orient="records")
 
 
+def node_identifier(ecli, itemid):
+    """Canonical citation-network identifier for a document.
+
+    Prefers the ECLI; documents without one (communicated cases, CLIN
+    notes) fall back to their HUDOC itemid so their citations are kept.
+    Returns None when neither is available.
+    """
+    for value in (ecli, itemid):
+        if pd.notna(value):
+            value = str(value).strip()
+            if value:
+                return value
+    return None
+
+
 def retrieve_edges_list(df, df_unfiltered):
     """
     OPTIMIZED VERSION: Returns a dataframe consisting of 2 columns 'ecli' and 'references' which
@@ -75,18 +106,6 @@ def retrieve_edges_list(df, df_unfiltered):
                         appno_index[appno] = []
                     appno_index[appno].append(idx)
 
-    # Index by extractedappno -> list of rows
-    extractedappno_index = {}
-    for idx, row in df_unfiltered.iterrows():
-        if pd.notna(row.extractedappno):
-            appnos = str(row.extractedappno).split(";")
-            for appno in appnos:
-                appno = appno.strip()
-                if appno:
-                    if appno not in extractedappno_index:
-                        extractedappno_index[appno] = []
-                    extractedappno_index[appno].append(idx)
-
     # Index by docname (normalized) -> list of rows
     docname_index = {}
     for idx, row in df_unfiltered.iterrows():
@@ -104,7 +123,7 @@ def retrieve_edges_list(df, df_unfiltered):
     for idx, row in df_unfiltered.iterrows():
         if pd.notna(row.judgementdate):
             try:
-                date = dateparser.parse(str(row.judgementdate))
+                date = parse_date_cached(str(row.judgementdate))
                 if date:
                     date_cache[idx] = date
                     year_cache[idx] = date.year
@@ -117,15 +136,17 @@ def retrieve_edges_list(df, df_unfiltered):
         if pd.notna(row.languageisocode):
             lang_cache[idx] = str(row.languageisocode).upper()
 
-    # Pre-store ECLIs
+    # Pre-store node identifiers: prefer ECLI, fall back to itemid for
+    # documents without one (communicated cases, CLIN notes). An empty
+    # string must never be used — all such documents would collapse into
+    # a single phantom node.
     ecli_cache = {}
     for idx, row in df_unfiltered.iterrows():
-        if pd.notna(row.ecli):
-            ecli_cache[idx] = str(row.ecli)
+        ecli_cache[idx] = node_identifier(row.ecli, getattr(row, "itemid", None))
+    ecli_cache = {idx: ident for idx, ident in ecli_cache.items() if ident}
 
     logging.info("Indexes created:")
     logging.info(f"  - Appno index: {len(appno_index)} entries")
-    logging.info(f"  - Extracted appno index: {len(extractedappno_index)} entries")
     logging.info(f"  - Docname index: {len(docname_index)} entries")
     logging.info(f"  - Date cache: {len(date_cache)} entries")
 
@@ -146,11 +167,6 @@ def retrieve_edges_list(df, df_unfiltered):
         leave=True,
     ):
         eclis = set()
-        extracted_appnos = []
-        if pd.notna(item.extractedappno):
-            extracted_appnos = [
-                x.strip() for x in str(item.extractedappno).split(";") if x.strip()
-            ]
 
         if pd.notna(item.scl):
             ref_list = str(item.scl).split(";")
@@ -163,39 +179,40 @@ def retrieve_edges_list(df, df_unfiltered):
             tot_num_refs += len(new_ref_list)
 
             for ref in new_ref_list:
-                # Extract application numbers from reference
+                # Extract application numbers from the reference text
+                # itself. The citing document's extractedappno list must
+                # NOT be blended in here: it contains every application
+                # number mentioned anywhere in the full text, so using it
+                # per reference links each citation to every case the
+                # document mentions.
                 app_numbers = re.findall(r"[0-9]{3,5}\/[0-9]{2}", ref)
-                if extracted_appnos:
-                    app_numbers.extend(extracted_appnos)
                 app_numbers = [x.strip() for x in app_numbers if x.strip()]
 
                 # Find matching cases
                 candidate_indices = set()
 
-                # First try by application number (fastest)
+                # First try by application number (fastest). Only match
+                # cases whose OWN application number it is — matching
+                # extractedappno here would link the citation to every
+                # document that merely mentions that number.
                 if app_numbers:
                     for appno in app_numbers:
                         if appno in appno_index:
                             candidate_indices.update(appno_index[appno])
-                        if appno in extractedappno_index:
-                            candidate_indices.update(extractedappno_index[appno])
 
                 # If no matches, try by casename
                 if not candidate_indices:
                     casename = get_casename(ref)
                     if casename:
-                        # Normalize casename for lookup (use same logic as lookup_casename)
+                        # Normalize casename for lookup. The docname index keys
+                        # are fully uppercased, so the lookup text must stay
+                        # uppercase too (no "V." -> "v." style case flips, or
+                        # the substring comparison below can never match).
                         patterns = clean_pattern
                         uptext = casename.upper()
 
-                        if "NO." in uptext:
-                            uptext = uptext.replace("NO.", "No.")
                         if "BV" in uptext:
                             uptext = uptext.replace("BV", "B.V.")
-                        if "v." in casename:
-                            uptext = uptext.replace("V.", "v.")
-                        else:
-                            uptext = uptext.replace("C.", "c.")
 
                         for pattern in patterns:
                             uptext = re.sub(pattern, "", uptext)
@@ -207,11 +224,19 @@ def retrieve_edges_list(df, df_unfiltered):
                         if uptext in docname_index:
                             candidate_indices.update(docname_index[uptext])
                         else:
-                            # Try partial match (only if needed - this is slower)
-                            # Limit to first 100 matches to avoid performance issues
+                            # Try partial match (only if needed - this is
+                            # slower). The containment must align on word
+                            # boundaries: short names like "A v. POLAND"
+                            # would otherwise match inside every
+                            # "...a v. Poland"-suffixed docname.
+                            padded_uptext = f" {uptext} "
                             matches_found = 0
                             for docname, indices in docname_index.items():
-                                if uptext in docname or docname in uptext:
+                                padded_docname = f" {docname} "
+                                if (
+                                    padded_uptext in padded_docname
+                                    or padded_docname in padded_uptext
+                                ):
                                     candidate_indices.update(indices)
                                     matches_found += len(indices)
                                     if matches_found > 100:  # Limit to prevent slowdown
@@ -246,7 +271,7 @@ def retrieve_edges_list(df, df_unfiltered):
                             if idx in df_unfiltered.index:
                                 row = df_unfiltered.loc[idx]
                                 if pd.notna(row.judgementdate):
-                                    date = dateparser.parse(str(row.judgementdate))
+                                    date = parse_date_cached(str(row.judgementdate))
                                     if date and date.year != year_from_ref:
                                         continue
                         except (ValueError, TypeError, AttributeError):
@@ -262,9 +287,12 @@ def retrieve_edges_list(df, df_unfiltered):
                     count += 1
                     missing_cases.append(ref)
 
-            # Add edges for this case
-            if eclis and pd.notna(item.ecli):
-                edges_list.append({"ecli": str(item.ecli), "references": list(eclis)})
+            # Add edges for this case, keyed by ECLI or itemid fallback.
+            # A case must not reference itself (original behavior).
+            citing_id = node_identifier(item.ecli, getattr(item, "itemid", None))
+            eclis.discard(citing_id)
+            if eclis and citing_id:
+                edges_list.append({"ecli": citing_id, "references": list(eclis)})
 
     logging.info(f"\nNumber of missed cases: {count}")
     logging.info(f"Total number of references: {tot_num_refs}")
@@ -282,81 +310,6 @@ def retrieve_edges_list(df, df_unfiltered):
     missing_df = pd.DataFrame({"missing_references": missing_cases})
 
     return edges, missing_df
-
-
-def lookup_app_number(pattern, df):
-    """
-    Returns a list with rows containing the cases linked to the found app numbers.
-    """
-    # Handle case where appno might not exist
-    if "appno" not in df.columns:
-        return pd.DataFrame()
-
-    row = df.loc[df["appno"].isin(pattern)]
-
-    if row.empty:
-        return pd.DataFrame()
-    elif row.shape[0] > 1:
-        return row
-    else:
-        return row
-
-
-def lookup_casename(ref, df):
-    """
-    Process the reference for lookup in metadata.
-    Returns the rows corresponding to the cases.
-
-    - Example of the processing (2 variants) -
-
-    Original reference from scl:
-    - Hentrich v. France, 22 September 1994, § 42, Series A no. 296-A
-    - Eur. Court H.R. James and Others judgment of 21 February 1986,
-    Series A no. 98, p. 46, para. 81
-
-    Split on ',' and take first item:
-    Hentrich v. France
-    Eur. Court H.R. James and Others judgment of 21 February 1986
-
-    If certain pattern from CLEAN_REF in case name, then remove:
-    Eur. Court H.R. James and Others judgment of 21 February 1986 -->
-        James and Others
-
-    Change name to upper case and add additional text to match metadata:
-    Hentrich v. France --> CASE OF HENTRICH V. FRANCE
-    James and Others --> CASE OF JAMES AND OTHERS
-    """
-    name = get_casename(ref)
-
-    # DEV note: In case, add more patterns to clean_ref.py in future
-    patterns = clean_pattern
-
-    uptext = name.upper()
-
-    if "NO." in uptext:
-        uptext = uptext.replace("NO.", "No.")
-
-    if "BV" in uptext:
-        uptext = uptext.replace("BV", "B.V.")
-
-    if "V." in name:
-        uptext = uptext.replace("V.", "v.")
-    else:
-        uptext = uptext.replace("C.", "c.")
-
-    for pattern in patterns:
-        uptext = re.sub(pattern, "", uptext)
-
-    uptext = re.sub(r"\[.*", "", uptext)
-    uptext = uptext.strip()
-    row = df[
-        df["docname"].str.contains(uptext, regex=False, flags=re.IGNORECASE, na=False)
-    ]
-
-    # if len(row) == 0:
-    #     print("no cases matched: ", name)
-
-    return row
 
 
 def get_casename(ref):
@@ -388,7 +341,7 @@ def get_year_from_ref(ref):
         if "§" in component:
             continue
         component = re.sub("judgment of ", "", component)
-        parsed_date = dateparser.parse(component)
+        parsed_date = parse_date_cached(component)
         if parsed_date is not None:
             date = parsed_date
         elif "ECHR" in component or "CEDH" in component:
@@ -397,7 +350,7 @@ def get_year_from_ref(ref):
             date_str = date_str.strip()
             date_str = re.sub("-.*", "", date_str)
             date_str = re.sub(r"\s.*", "", date_str)
-            date = dateparser.parse(date_str)
+            date = parse_date_cached(date_str)
 
     try:
         if date is not None:
@@ -418,6 +371,8 @@ def echr_nodes_edges(metadata_path=None, data=None):
     logging.info("\n--- COLLECTING METADATA ---\n")
     if metadata_path:
         data = open_metadata(metadata_path)
+        if data is False:
+            return "", "", ""
     elif data is None:
         logging.warning("No dataframe data provided. Returning...")
         return "", "", ""

--- a/src/echr_extractor/ECHR_reference_resolver.py
+++ b/src/echr_extractor/ECHR_reference_resolver.py
@@ -1,0 +1,404 @@
+"""Resolve citation references against HUDOC or an offline reference set.
+
+The citation network built by echr_nodes_edges is self-enclosed: edges
+only point at documents present in the corpus that was passed in.
+References to cases outside that corpus are reported in the missing
+references table (see MISSING_REFERENCE_COLUMNS). This module resolves
+those references to real HUDOC documents, either:
+
+- offline, against a larger metadata DataFrame (``reference_df``), or
+- online, by querying HUDOC with batched application-number and
+  casename queries (re-using the metadata scraper).
+
+References that cannot be resolved are returned untouched, never
+dropped.
+"""
+
+import logging
+import re
+
+import pandas as pd
+
+from .ECHR_metadata_harvester import basic_function, get_r
+from .ECHR_nodes_edges_list_transform import (
+    MISSING_REFERENCE_COLUMNS,
+    get_casename,
+    get_year_from_ref,
+    node_identifier,
+    parse_date_cached,
+)
+
+RESOLVER_FIELDS = [
+    "itemid",
+    "appno",
+    "docname",
+    "ecli",
+    "languageisocode",
+    "judgementdate",
+    "kpdate",
+    "doctype",
+    "doctypebranch",
+    "documentcollectionid2",
+]
+
+RESOLVED_COLUMNS = MISSING_REFERENCE_COLUMNS + [
+    "resolved_id",
+    "resolved_itemid",
+    "resolved_docname",
+    "match_method",
+    "candidate_count",
+]
+
+_APPNOS_PER_QUERY = 20
+_CASENAMES_PER_QUERY = 10
+_PAGE_LENGTH = 500
+
+
+def parse_scl_references(scl, citing_id=None):
+    """Parse an scl citation string into one row per reference.
+
+    Returns a DataFrame with MISSING_REFERENCE_COLUMNS, the same shape
+    as the missing-references table produced by the network builder.
+    """
+    rows = []
+    if scl is None or (isinstance(scl, float) and pd.isna(scl)):
+        return pd.DataFrame(columns=MISSING_REFERENCE_COLUMNS)
+    for ref in str(scl).split(";"):
+        ref = re.sub("\n", "", ref).strip()
+        if not ref:
+            continue
+        appnos = [
+            x.strip()
+            for x in re.findall(r"[0-9]{3,5}\/[0-9]{2}", ref)
+            if x.strip()
+        ]
+        components = ref.split(",")
+        year = get_year_from_ref(components)
+        rows.append(
+            {
+                "citing_id": citing_id,
+                "missing_references": ref,
+                "extracted_appnos": ";".join(appnos),
+                "casename": str(get_casename(ref) or "").strip(),
+                "year": year if year > 0 else None,
+                "ref_language": "ENG" if "v." in components[0] else "FRE",
+            }
+        )
+    if not rows:
+        return pd.DataFrame(columns=MISSING_REFERENCE_COLUMNS)
+    return pd.DataFrame(rows).drop_duplicates(
+        subset=["citing_id", "missing_references"]
+    ).reset_index(drop=True)
+
+
+def _normalize_casename(casename):
+    uptext = str(casename).upper()
+    if "BV" in uptext:
+        uptext = uptext.replace("BV", "B.V.")
+    uptext = re.sub(r"\[.*", "", uptext)
+    return uptext.strip()
+
+
+def _fetch_candidates(query, timeout, retry_attempts, max_attempts, verbose):
+    """Run one HUDOC query and return the result rows."""
+    base = (
+        "https://hudoc.echr.coe.int/app/query/results?query=contentsitename:ECHR"
+        " AND (NOT (doctype=PR OR doctype=HFCOMOLD OR doctype=HECOMOLD)) AND "
+        f"{query}&select={','.join(RESOLVER_FIELDS)}"
+        "&sort=itemid Ascending&start={start}&length={length}"
+    )
+    base = base.replace(" ", "%20").replace('"', "%22")
+
+    results = []
+    start = 0
+    while True:
+        url = base.format(start=start, length=_PAGE_LENGTH)
+        r = get_r(url, timeout, retry_attempts, verbose, max_attempts)
+        if r is None:
+            logging.warning("Reference resolution query failed; some "
+                            "references may stay unresolved")
+            break
+        try:
+            payload = r.json()
+            page = [res["columns"] for res in payload["results"]]
+        except (KeyError, ValueError) as e:
+            logging.warning(f"Could not parse resolution response: {e}")
+            break
+        results.extend(page)
+        start += _PAGE_LENGTH
+        if start >= payload.get("resultcount", 0) or not page:
+            break
+    return results
+
+
+def _candidate_pool_online(
+    missing_df, timeout, retry_attempts, max_attempts, verbose
+):
+    """Fetch candidate documents from HUDOC for all unique references."""
+    appnos = set()
+    casenames = set()
+    for _, row in missing_df.iterrows():
+        row_appnos = [
+            a.strip() for a in str(row["extracted_appnos"] or "").split(";")
+            if a.strip()
+        ]
+        if row_appnos:
+            appnos.update(row_appnos)
+        elif str(row["casename"] or "").strip():
+            casenames.add(str(row["casename"]).strip())
+
+    candidates = []
+    appno_list = sorted(appnos)
+    for i in range(0, len(appno_list), _APPNOS_PER_QUERY):
+        chunk = appno_list[i : i + _APPNOS_PER_QUERY]
+        candidates.extend(
+            _fetch_candidates(
+                basic_function("appno", chunk),
+                timeout, retry_attempts, max_attempts, verbose,
+            )
+        )
+    casename_list = sorted(casenames)
+    for i in range(0, len(casename_list), _CASENAMES_PER_QUERY):
+        chunk = casename_list[i : i + _CASENAMES_PER_QUERY]
+        candidates.extend(
+            _fetch_candidates(
+                basic_function("docname", chunk),
+                timeout, retry_attempts, max_attempts, verbose,
+            )
+        )
+    if not candidates:
+        return pd.DataFrame(columns=RESOLVER_FIELDS)
+    pool = pd.DataFrame(candidates)
+    return pool.drop_duplicates(subset=["itemid"]).reset_index(drop=True)
+
+
+def _index_pool(pool):
+    appno_index, docname_index = {}, {}
+    rows = []
+    for _, row in pool.iterrows():
+        ident = node_identifier(row.get("ecli"), row.get("itemid"))
+        if not ident:
+            continue
+        year = None
+        for date_col in ("judgementdate", "kpdate"):
+            value = row.get(date_col)
+            if pd.notna(value) and str(value).strip():
+                date = parse_date_cached(str(value))
+                if date:
+                    year = date.year
+                    break
+        lang = (
+            str(row.get("languageisocode")).upper()
+            if pd.notna(row.get("languageisocode"))
+            else ""
+        )
+        collection = (
+            str(row.get("documentcollectionid2")).upper()
+            if pd.notna(row.get("documentcollectionid2"))
+            else ""
+        )
+        entry = {
+            "ident": ident,
+            "itemid": str(row.get("itemid") or ""),
+            "docname": str(row.get("docname") or ""),
+            "year": year,
+            "lang": lang,
+            "is_judgment": "JUDGMENTS" in collection
+            or str(row.get("doctype") or "").startswith("HEJUD"),
+        }
+        rows.append(entry)
+        pos = len(rows) - 1
+        if pd.notna(row.get("appno")):
+            for a in str(row["appno"]).split(";"):
+                a = a.strip()
+                if a:
+                    appno_index.setdefault(a, []).append(pos)
+        docname = str(row.get("docname") or "").strip().upper()
+        if docname:
+            docname_index.setdefault(docname, []).append(pos)
+    return rows, appno_index, docname_index
+
+
+def _filter_candidates(positions, entries, row):
+    year = row["year"]
+    ref_lang = str(row["ref_language"] or "")
+    survivors = []
+    for pos in positions:
+        entry = entries[pos]
+        if ref_lang and entry["lang"] and ref_lang not in entry["lang"]:
+            continue
+        if pd.notna(year) and year and entry["year"] and entry["year"] != int(year):
+            continue
+        survivors.append(entry)
+    return survivors
+
+
+def _match_reference(row, entries, appno_index, docname_index):
+    """Pick the best candidate for one reference; None if none survive.
+
+    Application numbers are tried first; like the network builder, the
+    casename is used as a fallback when they match nothing.
+    """
+    appnos = [
+        a.strip() for a in str(row["extracted_appnos"] or "").split(";")
+        if a.strip()
+    ]
+    survivors, method = [], "none"
+    if appnos:
+        positions = set()
+        for a in appnos:
+            positions.update(appno_index.get(a, []))
+        survivors = _filter_candidates(positions, entries, row)
+        method = "appno"
+
+    if not survivors:
+        uptext = _normalize_casename(row["casename"])
+        if not uptext:
+            return None, method if appnos else "none", 0
+        positions = set()
+        if uptext in docname_index:
+            positions.update(docname_index[uptext])
+        else:
+            padded_up = f" {uptext} "
+            for docname, pos_list in docname_index.items():
+                if padded_up in f" {docname} " or f" {docname} " in padded_up:
+                    positions.update(pos_list)
+        casename_survivors = _filter_candidates(positions, entries, row)
+        if casename_survivors:
+            survivors, method = casename_survivors, "casename"
+
+    if not survivors:
+        return None, method, 0
+    # Deterministic best: prefer judgments, then stable itemid order
+    survivors.sort(key=lambda e: (not e["is_judgment"], e["itemid"]))
+    return survivors[0], method, len(survivors)
+
+
+def _match_rows(rows_df, pool):
+    """Match every reference row against the candidate pool."""
+    entries, appno_index, docname_index = _index_pool(pool)
+    resolved_rows, missing_rows = [], []
+    resolved_itemids = set()
+    for _, row in rows_df.iterrows():
+        entry, method, n_candidates = _match_reference(
+            row, entries, appno_index, docname_index
+        )
+        # A citation must never resolve to the citing document itself
+        if entry is not None and entry["ident"] == row["citing_id"]:
+            entry = None
+        if entry is None:
+            missing_rows.append(row)
+            continue
+        resolved = dict(row)
+        resolved.update(
+            {
+                "resolved_id": entry["ident"],
+                "resolved_itemid": entry["itemid"],
+                "resolved_docname": entry["docname"],
+                "match_method": method,
+                "candidate_count": n_candidates,
+            }
+        )
+        resolved_rows.append(resolved)
+        resolved_itemids.add(entry["itemid"])
+    return resolved_rows, missing_rows, resolved_itemids
+
+
+def resolve_references(
+    missing_df,
+    reference_df=None,
+    verbose=False,
+    timeout=60,
+    retry_attempts=3,
+    max_attempts=20,
+):
+    """Resolve unresolved citation references to real HUDOC documents.
+
+    :param pd.DataFrame missing_df: Missing-references table from
+        get_nodes_edges() (or parse_scl_references()).
+    :param pd.DataFrame reference_df: Optional metadata DataFrame to
+        resolve against offline. When omitted, HUDOC is queried with
+        batched application-number and casename lookups.
+    :return: tuple (resolved_df, external_nodes_df, still_missing_df).
+        resolved_df has RESOLVED_COLUMNS; external_nodes_df holds one
+        metadata row per distinct resolved document; still_missing_df
+        contains the rows that could not be resolved, unchanged.
+    """
+    if missing_df is None or len(missing_df) == 0:
+        return (
+            pd.DataFrame(columns=RESOLVED_COLUMNS),
+            pd.DataFrame(columns=RESOLVER_FIELDS),
+            pd.DataFrame(columns=MISSING_REFERENCE_COLUMNS),
+        )
+
+    if reference_df is not None:
+        pool = reference_df.copy()
+        for column in RESOLVER_FIELDS:
+            if column not in pool.columns:
+                pool[column] = None
+        pool = pool[RESOLVER_FIELDS]
+    else:
+        pool = _candidate_pool_online(
+            missing_df, timeout, retry_attempts, max_attempts, verbose
+        )
+
+    resolved_rows, still_missing_rows, resolved_itemids = _match_rows(
+        missing_df, pool
+    )
+
+    # Second online pass: references whose application numbers matched
+    # nothing (typos, cases known under a different number) can still
+    # resolve by casename, but their docname candidates were not fetched
+    # in the first pass.
+    if reference_df is None and still_missing_rows:
+        retry_df = pd.DataFrame(still_missing_rows)
+        retry_names = sorted(
+            {
+                str(name).strip()
+                for name, appnos in zip(
+                    retry_df["casename"], retry_df["extracted_appnos"]
+                )
+                if str(name or "").strip() and str(appnos or "").strip()
+            }
+        )
+        extra = []
+        for i in range(0, len(retry_names), _CASENAMES_PER_QUERY):
+            chunk = retry_names[i : i + _CASENAMES_PER_QUERY]
+            extra.extend(
+                _fetch_candidates(
+                    basic_function("docname", chunk),
+                    timeout, retry_attempts, max_attempts, verbose,
+                )
+            )
+        if extra:
+            pool = pd.concat(
+                [pool, pd.DataFrame(extra)], ignore_index=True
+            ).drop_duplicates(subset=["itemid"]).reset_index(drop=True)
+            retry_resolved, still_missing_rows, retry_itemids = _match_rows(
+                retry_df, pool
+            )
+            resolved_rows.extend(retry_resolved)
+            resolved_itemids |= retry_itemids
+
+    resolved_df = (
+        pd.DataFrame(resolved_rows)
+        if resolved_rows
+        else pd.DataFrame(columns=RESOLVED_COLUMNS)
+    )
+    still_missing_df = (
+        pd.DataFrame(still_missing_rows).reset_index(drop=True)
+        if still_missing_rows
+        else pd.DataFrame(columns=MISSING_REFERENCE_COLUMNS)
+    )
+    external_nodes_df = (
+        pool[pool["itemid"].isin(resolved_itemids)].reset_index(drop=True)
+        if len(pool)
+        else pd.DataFrame(columns=RESOLVER_FIELDS)
+    )
+
+    if verbose:
+        logging.info(
+            f"Resolved {len(resolved_df)} of {len(missing_df)} references "
+            f"({len(still_missing_df)} still unresolved)"
+        )
+    return resolved_df, external_nodes_df, still_missing_df

--- a/src/echr_extractor/__init__.py
+++ b/src/echr_extractor/__init__.py
@@ -3,10 +3,15 @@
 import logging
 
 from .echr import (
+    get_document_citations,
     get_echr,
     get_echr_extra,
     get_echr_segments,
     get_nodes_edges,
+)
+from .ECHR_reference_resolver import (
+    parse_scl_references,
+    resolve_references,
 )
 from .segmentation import (
     prepare_segmentation_corpus,
@@ -27,11 +32,14 @@ __email__ = "lawtech@maastrichtuniversity.nl"
 logging.basicConfig(level=logging.INFO)
 
 __all__ = [
+    "get_document_citations",
     "get_echr",
     "get_echr_extra",
     "get_echr_segments",
     "get_nodes_edges",
+    "parse_scl_references",
     "prepare_segmentation_corpus",
+    "resolve_references",
     "segment_document",
     "segment_documents",
 ]

--- a/src/echr_extractor/cli.py
+++ b/src/echr_extractor/cli.py
@@ -3,7 +3,13 @@
 import argparse
 import sys
 
-from . import get_echr, get_echr_extra, get_echr_segments, get_nodes_edges
+from . import (
+    get_document_citations,
+    get_echr,
+    get_echr_extra,
+    get_echr_segments,
+    get_nodes_edges,
+)
 
 
 def main() -> None:
@@ -39,6 +45,27 @@ def main() -> None:
     )
     network_parser.add_argument(
         "--no-save", action="store_true", help="Don't save files, return objects only"
+    )
+    network_parser.add_argument(
+        "--resolve-external",
+        action="store_true",
+        help="Resolve references pointing outside the corpus via HUDOC",
+    )
+
+    # Single-document citations command
+    citations_parser = subparsers.add_parser(
+        "citations", help="List and resolve the out-citations of one document"
+    )
+    citations_parser.add_argument(
+        "--itemid", type=str, required=True, help="HUDOC itemid of the document"
+    )
+    citations_parser.add_argument(
+        "--no-resolve",
+        action="store_true",
+        help="Only parse the citations, do not resolve them against HUDOC",
+    )
+    citations_parser.add_argument(
+        "--no-save", action="store_true", help="Don't save files, print summary only"
     )
 
     # Segmentation command
@@ -105,11 +132,37 @@ def main() -> None:
 
         elif args.command == "network":
             nodes, edges, missing_df = get_nodes_edges(
-                metadata_path=args.metadata_path, save_file="n" if args.no_save else "y"
+                metadata_path=args.metadata_path,
+                save_file="n" if args.no_save else "y",
+                resolve_external=args.resolve_external,
             )
             print(f"Generated {len(nodes)} nodes and {len(edges)} edges")
             if missing_df is not None and len(missing_df) > 0:
                 print(f"Found {len(missing_df)} missing references")
+
+        elif args.command == "citations":
+            result = get_document_citations(
+                itemid=args.itemid, resolve=not args.no_resolve
+            )
+            resolved_count = (
+                result["resolved_id"].notna().sum()
+                if "resolved_id" in result.columns
+                else 0
+            )
+            print(
+                f"Found {len(result)} citations for {args.itemid} "
+                f"({resolved_count} resolved)"
+            )
+            if not args.no_save and len(result) > 0:
+                import os as os_mod
+                from pathlib import Path as Path_mod
+
+                Path_mod("data").mkdir(parents=True, exist_ok=True)
+                out = os_mod.path.join(
+                    "data", f"echr_citations_{args.itemid}.csv"
+                )
+                result.to_csv(out, index=False)
+                print(f"Saved to {out}")
 
         elif args.command == "segment":
             import json as json_mod

--- a/src/echr_extractor/echr.py
+++ b/src/echr_extractor/echr.py
@@ -255,8 +255,80 @@ def get_echr_extra(
         return df, json_list
 
 
-def get_nodes_edges(metadata_path=None, df=None, save_file="y"):
+def get_nodes_edges(
+    metadata_path=None,
+    df=None,
+    save_file="y",
+    resolve_external=False,
+    reference_df=None,
+):
+    """Build the citation network for a metadata corpus.
+
+    The network is self-enclosed by default: edges only point at
+    documents present in the corpus. References to cases outside it are
+    returned in the third value (one row per citing document and
+    unresolved reference, with the parsed application numbers, casename,
+    year and language).
+
+    :param str metadata_path: Path to a metadata CSV file.
+    :param pd.DataFrame df: Metadata DataFrame (alternative to path).
+    :param str save_file: Whether to save results to data/ ("y"/"n").
+    :param bool resolve_external: Resolve references that point outside
+        the corpus by querying HUDOC (batched appno/casename lookups).
+        Resolved targets are added to the edges, and their metadata is
+        appended to the nodes with in_corpus=False.
+    :param pd.DataFrame reference_df: Resolve external references
+        offline against this larger metadata DataFrame instead of (or
+        before) querying HUDOC. Composes with resolve_external: offline
+        first, then HUDOC for the remainder.
+    :return: tuple (nodes, edges, missing_df). missing_df contains only
+        the references that stayed unresolved.
+    """
     nodes, edges, missing_df = echr_nodes_edges(metadata_path=metadata_path, data=df)
+    if isinstance(nodes, str):
+        # echr_nodes_edges could not produce a network (no/bad input)
+        return nodes, edges, missing_df
+
+    resolved_df = None
+    if reference_df is not None or resolve_external:
+        from .ECHR_reference_resolver import resolve_references
+
+        resolved_parts, external_parts = [], []
+        still_missing = missing_df
+        if reference_df is not None and len(still_missing) > 0:
+            resolved, external, still_missing = resolve_references(
+                still_missing, reference_df=reference_df
+            )
+            resolved_parts.append(resolved)
+            external_parts.append(external)
+        if resolve_external and len(still_missing) > 0:
+            resolved, external, still_missing = resolve_references(still_missing)
+            resolved_parts.append(resolved)
+            external_parts.append(external)
+
+        resolved_df = (
+            pd.concat(resolved_parts, ignore_index=True)
+            if resolved_parts
+            else pd.DataFrame()
+        )
+        external_nodes = (
+            pd.concat(external_parts, ignore_index=True).drop_duplicates(
+                subset=["itemid"]
+            )
+            if external_parts
+            else pd.DataFrame()
+        )
+        missing_df = still_missing
+
+        if len(resolved_df) > 0:
+            edges = _merge_resolved_into_edges(edges, resolved_df)
+            nodes = _append_external_nodes(nodes, external_nodes)
+            logging.info(
+                f"Resolved {len(resolved_df)} external references to "
+                f"{len(external_nodes)} documents; "
+                f"{len(missing_df)} references remain unresolved"
+            )
+
     if save_file == "y":
         Path("data").mkdir(parents=True, exist_ok=True)
         edges.to_csv(
@@ -273,9 +345,129 @@ def get_nodes_edges(metadata_path=None, df=None, save_file="y"):
                 index=False,
                 encoding="utf-8",
             )
-        return nodes, edges, missing_df
+        if resolved_df is not None and len(resolved_df) > 0:
+            resolved_df.to_csv(
+                os.path.join("data", "ECHR_resolved_references.csv"),
+                index=False,
+                encoding="utf-8",
+            )
 
     return nodes, edges, missing_df
+
+
+def _merge_resolved_into_edges(edges, resolved_df):
+    """Union resolved external targets into the per-case reference lists."""
+    edges_map = {
+        row["ecli"]: set(row["references"]) for _, row in edges.iterrows()
+    }
+    for citing_id, group in resolved_df.groupby("citing_id"):
+        targets = set(group["resolved_id"]) - {citing_id}
+        if targets:
+            edges_map.setdefault(citing_id, set()).update(targets)
+    merged = pd.DataFrame(
+        {
+            "ecli": sorted(edges_map),
+            "references": [sorted(edges_map[k]) for k in sorted(edges_map)],
+        }
+    )
+    return merged
+
+
+def _append_external_nodes(nodes, external_nodes):
+    """Append resolved out-of-corpus documents, flagged in_corpus=False."""
+    from .ECHR_nodes_edges_list_transform import node_identifier
+
+    nodes = nodes.assign(in_corpus=True)
+    if len(external_nodes) == 0:
+        return nodes
+    corpus_itemids = (
+        set(nodes["itemid"].astype(str)) if "itemid" in nodes.columns else set()
+    )
+    corpus_ids = set(
+        nodes.apply(
+            lambda row: node_identifier(row.get("ecli"), row.get("itemid")),
+            axis=1,
+        )
+    )
+    external = external_nodes[
+        ~external_nodes["itemid"].astype(str).isin(corpus_itemids)
+    ].copy()
+    external = external[
+        ~external.apply(
+            lambda row: node_identifier(row.get("ecli"), row.get("itemid")),
+            axis=1,
+        ).isin(corpus_ids)
+    ]
+    return pd.concat(
+        [nodes, external.assign(in_corpus=False)], ignore_index=True
+    )
+
+
+def get_document_citations(
+    itemid=None,
+    document=None,
+    resolve=True,
+    reference_df=None,
+    verbose=False,
+):
+    """Full out-citation list of a single document.
+
+    Parses the document's scl field into one row per cited case and,
+    unless resolve=False, resolves each citation to a real HUDOC
+    document (offline against reference_df when given, otherwise via
+    batched HUDOC queries). Unresolvable references are kept with empty
+    resolution columns rather than dropped.
+
+    :param str itemid: HUDOC itemid; the document's metadata (including
+        scl) is fetched automatically.
+    :param document: Alternatively, an in-memory mapping/Series with an
+        'scl' field (and optionally ecli/itemid).
+    :param bool resolve: Whether to resolve the parsed references.
+    :param pd.DataFrame reference_df: Optional offline reference corpus.
+    :return: DataFrame with one row per citation; resolved rows carry
+        resolved_id, resolved_itemid, resolved_docname, match_method.
+
+    Example:
+        citations = get_document_citations(itemid='001-100448')
+        resolved = citations[citations['resolved_id'].notna()]
+    """
+    from .ECHR_nodes_edges_list_transform import node_identifier
+    from .ECHR_reference_resolver import (
+        parse_scl_references,
+        resolve_references,
+    )
+
+    if itemid is None and document is None:
+        raise ValueError("Provide either itemid or document")
+
+    if document is None:
+        link = (
+            "https://hudoc.echr.coe.int/eng#"
+            f'{{"itemid":["{itemid}"]}}'
+        )
+        fetched = get_echr(
+            link=link,
+            save_file="n",
+            progress_bar=False,
+            verbose=verbose,
+            fields=["itemid", "ecli", "docname", "languageisocode", "scl"],
+        )
+        if fetched is False or len(fetched) == 0:
+            logging.warning(f"No document found for itemid {itemid}")
+            return pd.DataFrame()
+        document = fetched.iloc[0]
+
+    citing_id = node_identifier(
+        document.get("ecli"), document.get("itemid")
+    )
+    references = parse_scl_references(document.get("scl"), citing_id=citing_id)
+    if not resolve or len(references) == 0:
+        return references
+
+    resolved, _, still_missing = resolve_references(
+        references, reference_df=reference_df, verbose=verbose
+    )
+    return pd.concat([resolved, still_missing], ignore_index=True)
 
 
 def prepare_echr_corpus(df, full_texts):

--- a/src/echr_extractor/echr.py
+++ b/src/echr_extractor/echr.py
@@ -212,6 +212,10 @@ def get_echr_extra(
     :return: tuple of (pandas.DataFrame, list) containing metadata and full-text data,
              or (False, False) if extraction failed.
     """
+    # Mirror get_echr's count handling so saved file names match the ones
+    # get_echr would produce for the same parameters (e.g. 0-100, not 0-ALL)
+    if count:
+        end_id = int(start_id) + count
     df = get_echr(
         start_id=start_id,
         end_id=end_id,

--- a/src/echr_extractor/segmentation.py
+++ b/src/echr_extractor/segmentation.py
@@ -74,7 +74,11 @@ def _normalize_corpus_columns(df: pd.DataFrame) -> pd.DataFrame:
         for column in ["itemid", "languageisocode", "ecli", "doctype", "doctypebranch", "fulltext"]
         if column in normalized.columns
     ]
-    return normalized[ordered]
+    # Preserve any additional metadata columns (appno, article, scl, ...)
+    # after the canonical ones — prepare_echr_corpus documents that the
+    # metadata columns survive the merge.
+    extras = [column for column in normalized.columns if column not in ordered]
+    return normalized[ordered + extras]
 
 
 def _normalize_full_text_records(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,35 @@
 """Test configuration and fixtures."""
 
+import os
+
 import pandas as pd
 import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-live",
+        action="store_true",
+        default=False,
+        help="run tests that hit the real HUDOC API",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "live: test performs real HUDOC API requests "
+        "(skipped unless --run-live or ECHR_RUN_LIVE=1)",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-live") or os.environ.get("ECHR_RUN_LIVE") == "1":
+        return
+    skip_live = pytest.mark.skip(reason="live HUDOC test: pass --run-live to enable")
+    for item in items:
+        if "live" in item.keywords:
+            item.add_marker(skip_live)
 
 
 @pytest.fixture

--- a/tests/test_echr.py
+++ b/tests/test_echr.py
@@ -126,6 +126,26 @@ class TestGetECHRExtra:
 
     @patch("echr_extractor.echr.download_full_text_main")
     @patch("echr_extractor.echr.get_echr_metadata")
+    def test_get_echr_extra_saved_filenames_match_get_echr(
+        self, mock_get_metadata, mock_download_text, tmp_path, monkeypatch
+    ):
+        """Regression: with count=N, get_echr_extra used to save files
+        named 0-ALL while get_echr saved 0-N for the same parameters."""
+        monkeypatch.chdir(tmp_path)
+        mock_get_metadata.return_value = pd.DataFrame(
+            {"itemid": ["001-1", "001-2"]}
+        )
+        mock_download_text.return_value = [{"itemid": "001-1", "text": "t"}]
+
+        get_echr_extra(count=2, save_file="y")
+
+        assert (tmp_path / "data" / "echr_metadata_0-2_dates_START-END.csv").exists()
+        assert (
+            tmp_path / "data" / "echr_full_text_0-2_dates_START-END.json"
+        ).exists()
+
+    @patch("echr_extractor.echr.download_full_text_main")
+    @patch("echr_extractor.echr.get_echr_metadata")
     def test_get_echr_extra_metadata_failure(
         self, mock_get_metadata, mock_download_text
     ):
@@ -229,6 +249,27 @@ class TestSegmentationWorkflow:
         assert result.iloc[0]["fulltext"] == STANDARD_JUDGMENT_TEXT
         assert result.columns.tolist().count("ecli") == 1
         assert result.iloc[0]["ecli"] == "ECLI:ORIGINAL"
+
+    def test_prepare_echr_corpus_preserves_metadata_columns(self):
+        """Regression: the docstring promises 'metadata columns plus
+        fulltext', but extra columns used to be dropped in the merge."""
+        df = pd.DataFrame(
+            {
+                "itemid": ["001-1"],
+                "ecli": ["ECLI:X"],
+                "languageisocode": ["ENG"],
+                "appno": ["123/45"],
+                "article": ["6"],
+                "scl": ["Some v. Case, 1 January 2000"],
+            }
+        )
+        full_texts = [{"item_id": "001-1", "full_text": STANDARD_JUDGMENT_TEXT}]
+
+        result = prepare_echr_corpus(df, full_texts)
+
+        assert set(df.columns) <= set(result.columns)
+        assert result.iloc[0]["appno"] == "123/45"
+        assert result.iloc[0]["scl"] == "Some v. Case, 1 January 2000"
 
     def test_prepare_echr_corpus_empty_inputs_return_empty_dataframe(self):
         result = prepare_echr_corpus(False, None)

--- a/tests/test_html_downloader.py
+++ b/tests/test_html_downloader.py
@@ -1,4 +1,85 @@
-from echr_extractor.ECHR_html_downloader import get_full_text_from_html
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import requests as requests_module
+
+from echr_extractor.ECHR_html_downloader import (
+    download_full_text_main,
+    get_full_text_from_html,
+)
+
+
+def fake_html_response(status_code, body=""):
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = body
+    if status_code >= 400:
+        response.raise_for_status.side_effect = (
+            requests_module.exceptions.HTTPError(f"{status_code}")
+        )
+    else:
+        response.raise_for_status.return_value = None
+    return response
+
+
+class TestDownloadFullTextMain:
+    def test_error_pages_are_not_stored_as_text(self, caplog):
+        """A 404/500 body must never end up as a document's full_text;
+        permanently failing documents are dropped with a warning."""
+        df = pd.DataFrame(
+            {"itemid": ["001-1", "001-2"], "ecli": ["ECLI:1", "ECLI:2"]}
+        )
+        responses = {
+            "001-1": [fake_html_response(200, "<p>Real judgment text</p>")],
+            "001-2": [
+                fake_html_response(404, "<p>Not found</p>"),
+                fake_html_response(404, "<p>Not found</p>"),
+            ],
+        }
+
+        def fake_get(url, timeout):
+            item_id = url.rsplit("=", 1)[-1]
+            return responses[item_id].pop(0)
+
+        with patch(
+            "echr_extractor.ECHR_html_downloader.requests.get",
+            side_effect=fake_get,
+        ):
+            result = download_full_text_main(df, threads=1)
+
+        by_id = {r["item_id"]: r for r in result}
+        assert by_id["001-1"]["full_text"] == "Real judgment text"
+        assert "001-2" not in by_id
+        assert "could not be downloaded" in caplog.text
+
+    def test_failed_download_recovers_on_retry(self):
+        df = pd.DataFrame({"itemid": ["001-1"], "ecli": ["ECLI:1"]})
+        responses = [
+            fake_html_response(500),
+            fake_html_response(200, "<p>Recovered</p>"),
+        ]
+        with patch(
+            "echr_extractor.ECHR_html_downloader.requests.get",
+            side_effect=responses,
+        ):
+            result = download_full_text_main(df, threads=1)
+
+        assert len(result) == 1
+        assert result[0]["full_text"] == "Recovered"
+
+    def test_empty_conversion_is_kept_but_warned(self, caplog):
+        """HTTP 204 (no HTML conversion available) keeps the record with
+        empty text so alignment with metadata is preserved."""
+        df = pd.DataFrame({"itemid": ["001-1"], "ecli": ["ECLI:1"]})
+        with patch(
+            "echr_extractor.ECHR_html_downloader.requests.get",
+            return_value=fake_html_response(204, ""),
+        ):
+            result = download_full_text_main(df, threads=1)
+
+        assert len(result) == 1
+        assert result[0]["full_text"] == ""
+        assert "No HTML text available" in caplog.text
 
 
 def test_get_full_text_preserves_paragraphs_and_commas():

--- a/tests/test_live_hudoc.py
+++ b/tests/test_live_hudoc.py
@@ -13,7 +13,7 @@ network requests and take minutes rather than seconds.
 import pandas as pd
 import pytest
 
-from echr_extractor import get_echr, get_nodes_edges
+from echr_extractor import get_document_citations, get_echr, get_nodes_edges
 
 pytestmark = pytest.mark.live
 
@@ -183,6 +183,58 @@ class TestLiveLargeFetch:
         df = fetch(count=10500, language=["ENG"], fields=["itemid", "kpdate"])
         assert len(df) == 10500
         assert df["itemid"].is_unique
+
+
+class TestLiveReferenceResolution:
+    def test_single_document_out_citations(self):
+        """Sanoma Uitgevers B.V. v. the Netherlands [GC] cites ~20 cases;
+        the resolver must find most of them in HUDOC."""
+        result = get_document_citations(itemid="001-100448")
+        assert len(result) > 10
+        resolved = result[result["resolved_id"].notna()]
+        assert len(resolved) / len(result) > 0.6
+        # appno-resolved targets must carry the appno cited in the text
+        for _, row in resolved[resolved["match_method"] == "appno"].iterrows():
+            assert any(
+                a in row["missing_references"]
+                for a in row["extracted_appnos"].split(";")
+            )
+        # a famous known citation must be among them
+        assert (
+            resolved["resolved_docname"]
+            .str.contains("GOODWIN", case=False)
+            .any()
+        )
+
+    def test_network_with_external_resolution(self):
+        df = fetch(
+            start_date="2022-01-10",
+            end_date="2022-01-20",
+            fields=EDGE_FIELDS,
+        )
+        plain_nodes, plain_edges, plain_missing = get_nodes_edges(
+            df=df, save_file="n"
+        )
+        nodes, edges, missing = get_nodes_edges(
+            df=df, save_file="n", resolve_external=True
+        )
+        # resolution strictly reduces the unresolved set and adds nodes
+        assert len(missing) < len(plain_missing)
+        assert "in_corpus" in nodes.columns
+        external = nodes[~nodes["in_corpus"]]
+        assert len(external) > 0
+        assert len(nodes) == len(plain_nodes) + len(external)
+        # every edge target is now a known node identifier
+        known = set(
+            nodes.apply(
+                lambda r: str(r.get("ecli")).strip()
+                if pd.notna(r.get("ecli")) and str(r.get("ecli")).strip()
+                else str(r.get("itemid")),
+                axis=1,
+            )
+        )
+        for refs in edges["references"]:
+            assert set(refs) <= known
 
 
 class TestLiveCitationNetwork:

--- a/tests/test_live_hudoc.py
+++ b/tests/test_live_hudoc.py
@@ -1,0 +1,237 @@
+"""Live integration tests against the real HUDOC API.
+
+Skipped by default; enable with:
+
+    pytest --run-live tests/test_live_hudoc.py
+    # or
+    ECHR_RUN_LIVE=1 pytest tests/test_live_hudoc.py
+
+These tests keep result counts small where possible, but they do real
+network requests and take minutes rather than seconds.
+"""
+
+import pandas as pd
+import pytest
+
+from echr_extractor import get_echr, get_nodes_edges
+
+pytestmark = pytest.mark.live
+
+FIELDS = [
+    "itemid",
+    "docname",
+    "kpdate",
+    "languageisocode",
+    "article",
+    "respondent",
+    "documentcollectionid2",
+]
+
+EDGE_FIELDS = [
+    "itemid",
+    "appno",
+    "article",
+    "conclusion",
+    "docname",
+    "doctype",
+    "doctypebranch",
+    "ecli",
+    "importance",
+    "judgementdate",
+    "languageisocode",
+    "originatingbody",
+    "violation",
+    "nonviolation",
+    "extractedappno",
+    "scl",
+]
+
+
+def fetch(**kwargs):
+    defaults = dict(save_file="n", progress_bar=False, verbose=False)
+    defaults.update(kwargs)
+    return get_echr(**defaults)
+
+
+def trace_references(df, edges):
+    """Count how many edge references are supported by the citing scl."""
+
+    def ident(row):
+        ecli = row["ecli"]
+        if pd.notna(ecli) and str(ecli).strip():
+            return str(ecli).strip()
+        return str(row["itemid"]).strip()
+
+    lookup = df.assign(_id=df.apply(ident, axis=1)).set_index("_id", drop=False)
+    lookup = lookup[~lookup.index.duplicated(keep="first")]
+    traced = total = 0
+    for _, edge in edges.iterrows():
+        citing = lookup.loc[[edge["ecli"]]].iloc[0]
+        scl = str(citing["scl"]).upper()
+        for ref_id in edge["references"]:
+            total += 1
+            cited = lookup.loc[[ref_id]].iloc[0]
+            appnos = [
+                a.strip() for a in str(cited["appno"]).split(";") if a.strip()
+            ]
+            surname = (
+                str(cited["docname"])
+                .upper()
+                .replace("CASE OF ", "")
+                .replace("AFFAIRE ", "")
+                .split(" V.")[0]
+                .split(" C.")[0]
+                .strip()
+            )
+            if any(a in scl for a in appnos) or (
+                len(surname) > 3 and surname in scl
+            ):
+                traced += 1
+    return traced, total
+
+
+class TestLiveFilters:
+    def test_baseline_fetch(self):
+        df = fetch(count=10, fields=FIELDS)
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 10
+        assert df["itemid"].notna().all()
+
+    def test_date_filter_bounds_are_respected(self):
+        df = fetch(
+            count=50,
+            start_date="2023-01-01",
+            end_date="2023-06-30",
+            fields=FIELDS,
+        )
+        assert len(df) > 0
+        dates = pd.to_datetime(df["kpdate"])
+        assert (dates >= "2023-01-01").all()
+        assert (dates <= "2023-06-30 23:59:59").all()
+
+    def test_single_day_date_range(self):
+        """Regression: single-day ranges used to produce zero batches."""
+        # 2023-01-24 is a Tuesday with published judgments
+        df = fetch(count=20, start_date="2023-01-24", end_date="2023-01-24")
+        assert df is not False
+        assert len(df) > 0
+
+    def test_language_filter(self):
+        df = fetch(count=30, language=["FRE"], fields=FIELDS)
+        assert len(df) > 0
+        assert (df["languageisocode"] == "FRE").all()
+
+    def test_multiple_languages(self):
+        df = fetch(count=100, language=["ENG", "FRE"], fields=FIELDS)
+        assert set(df["languageisocode"].unique()) <= {"ENG", "FRE"}
+
+    def test_link_with_article_and_respondent_filters(self):
+        """Regression: unmapped link keys were silently dropped, so this
+        used to return the entire database instead of ~60 cases."""
+        link = (
+            "https://hudoc.echr.coe.int/eng#"
+            '{%22article%22:[%2210%22],%22respondent%22:[%22NLD%22],'
+            "%22documentcollectionid2%22:[%22JUDGMENTS%22]}"
+        )
+        df = fetch(link=link, fields=FIELDS)
+        assert df is not False
+        # Article 10 v. Netherlands judgments: a small, stable set
+        assert len(df) < 500
+        assert df["article"].str.split(";").apply(lambda a: "10" in a).all()
+        assert (df["respondent"].str.split(";").apply(lambda r: "NLD" in r)).all()
+
+    def test_link_with_docname_and_kpdate(self):
+        link = (
+            "https://hudoc.echr.coe.int/eng#"
+            '{%22docname%22:[%22turkey%22],'
+            "%22kpdate%22:[%222020-01-01%22,%222020-12-31%22]}"
+        )
+        df = fetch(count=50, link=link, fields=FIELDS)
+        assert len(df) > 0
+        assert df["docname"].str.contains("turkey", case=False).all()
+        dates = pd.to_datetime(df["kpdate"])
+        assert (dates.dt.year == 2020).all()
+
+    def test_link_with_itemid(self):
+        link = (
+            "https://hudoc.echr.coe.int/eng#"
+            "{%22itemid%22:[%22001-100448%22]}"
+        )
+        df = fetch(link=link, fields=FIELDS)
+        assert len(df) == 1
+        assert df.iloc[0]["itemid"] == "001-100448"
+
+    def test_query_payload(self):
+        payload = (
+            "(contentsitename=ECHR)%20AND%20"
+            "(documentcollectionid2:%22JUDGMENTS%22)"
+        )
+        df = fetch(count=10, query_payload=payload, fields=FIELDS)
+        assert len(df) == 10
+        assert (
+            df["documentcollectionid2"]
+            .str.contains("JUDGMENTS", case=False)
+            .all()
+        )
+
+
+class TestLiveLargeFetch:
+    def test_fetch_beyond_hudoc_10k_pagination_cap(self):
+        """Regression: HUDOC caps pagination at 10,000 rows per query;
+        count=15000 used to silently return exactly 10,000. The query
+        must be partitioned into date windows automatically."""
+        df = fetch(count=10500, language=["ENG"], fields=["itemid", "kpdate"])
+        assert len(df) == 10500
+        assert df["itemid"].is_unique
+
+
+class TestLiveCitationNetwork:
+    def test_small_network(self):
+        """~3 months of judgments: the network must resolve real citations."""
+        df = fetch(
+            start_date="2022-01-01",
+            end_date="2022-03-31",
+            fields=EDGE_FIELDS,
+        )
+        assert df is not False and len(df) > 100
+
+        nodes, edges, missing = get_nodes_edges(df=df, save_file="n")
+
+        assert len(nodes) == len(df)
+        assert len(edges) > 0
+        # Every resolved reference must be a non-empty identifier (ECLI,
+        # or itemid for documents without one) present in the corpus;
+        # empty-string ECLIs used to leak in as phantom nodes
+        known_ids = (set(df["ecli"].dropna()) | set(df["itemid"].dropna())) - {""}
+        for refs in edges["references"]:
+            assert "" not in refs
+            assert set(refs) <= known_ids
+        # Semantic check: references must trace back to the citing
+        # case's scl text (by application number or case surname).
+        # Guards against over-linking regressions (extractedappno
+        # blending, substring matches on short docnames).
+        traced, total = trace_references(df, edges)
+        assert total > 0
+        assert traced / total > 0.9, f"only {traced}/{total} references traced"
+
+    def test_large_network(self):
+        """Two years of judgments (~several thousand cases)."""
+        df = fetch(
+            start_date="2019-01-01",
+            end_date="2020-12-31",
+            fields=EDGE_FIELDS,
+        )
+        assert df is not False and len(df) > 2000
+
+        nodes, edges, missing = get_nodes_edges(df=df, save_file="n")
+
+        assert len(nodes) == len(df)
+        assert len(edges) > 20
+        known_ids = (set(df["ecli"].dropna()) | set(df["itemid"].dropna())) - {""}
+        for refs in edges["references"]:
+            assert "" not in refs
+            assert set(refs) <= known_ids
+        # Edges are aggregated: one row per citing ECLI
+        assert edges["ecli"].is_unique
+        traced, total = trace_references(df, edges)
+        assert traced / total > 0.9, f"only {traced}/{total} references traced"

--- a/tests/test_metadata_harvester.py
+++ b/tests/test_metadata_harvester.py
@@ -10,7 +10,6 @@ import urllib.parse
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
-import pytest
 
 from echr_extractor.ECHR_metadata_harvester import (
     basic_function,

--- a/tests/test_metadata_harvester.py
+++ b/tests/test_metadata_harvester.py
@@ -1,0 +1,411 @@
+"""Unit tests for the metadata harvester query building and fetching.
+
+These tests exercise the real query-construction code (link_to_query,
+determine_meta_url, get_echr_metadata) without network access; HTTP calls
+are mocked at the requests layer. Live end-to-end coverage lives in
+test_live_hudoc.py.
+"""
+
+import urllib.parse
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from echr_extractor.ECHR_metadata_harvester import (
+    basic_function,
+    determine_meta_url,
+    get_date_ranges,
+    get_echr_metadata,
+    link_to_query,
+    split_date_range,
+)
+
+
+def hudoc_link(fragment):
+    """Build a HUDOC advanced-search link from a raw JSON fragment."""
+    return "https://hudoc.echr.coe.int/eng#" + urllib.parse.quote(fragment)
+
+
+class TestBasicFunction:
+    def test_single_value(self):
+        assert basic_function("docname", ["turkey"]) == (
+            '((docname="turkey") OR (docname:"turkey"))'
+        )
+
+    def test_multiple_values_joined_with_or(self):
+        query = basic_function("languageisocode", ["ENG", "FRE"])
+        assert '(languageisocode="ENG") OR (languageisocode:"ENG")' in query
+        assert '(languageisocode="FRE") OR (languageisocode:"FRE")' in query
+        assert query.count(" OR ") == 3
+
+
+class TestGetDateRanges:
+    def test_no_dates_returns_single_range(self):
+        assert get_date_ranges(None, None) == [(None, None)]
+
+    def test_range_within_batch_size(self):
+        assert get_date_ranges("2023-01-01", "2023-06-30", days_per_batch=365) == [
+            ("2023-01-01", "2023-06-30")
+        ]
+
+    def test_range_split_into_batches(self):
+        ranges = get_date_ranges("2020-01-01", "2021-12-31", days_per_batch=365)
+        assert len(ranges) == 3
+        assert ranges[0] == ("2020-01-01", "2020-12-30")
+        assert ranges[1] == ("2020-12-31", "2021-12-30")
+        assert ranges[2] == ("2021-12-31", "2021-12-31")
+
+    def test_single_day_range_is_not_dropped(self):
+        """Regression: a one-day range used to produce zero batches."""
+        assert get_date_ranges("2023-05-01", "2023-05-01") == [
+            ("2023-05-01", "2023-05-01")
+        ]
+
+    def test_final_day_remainder_is_not_dropped(self):
+        """Regression: a remainder of exactly one day used to be lost."""
+        ranges = get_date_ranges("2020-01-01", "2020-01-11", days_per_batch=10)
+        assert ranges == [
+            ("2020-01-01", "2020-01-10"),
+            ("2020-01-11", "2020-01-11"),
+        ]
+
+    def test_batches_are_contiguous_without_overlap(self):
+        ranges = get_date_ranges("2019-01-01", "2022-12-31", days_per_batch=180)
+        for (_, prev_end), (next_start, _) in zip(ranges, ranges[1:]):
+            prev = pd.Timestamp(prev_end)
+            nxt = pd.Timestamp(next_start)
+            assert (nxt - prev).days == 1
+
+
+class TestSplitDateRange:
+    def test_bisects_without_gap_or_overlap(self):
+        halves = split_date_range("2020-01-01", "2020-12-31")
+        assert halves[0][0] == "2020-01-01"
+        assert halves[1][1] == "2020-12-31"
+        gap = pd.Timestamp(halves[1][0]) - pd.Timestamp(halves[0][1])
+        assert gap.days == 1
+
+    def test_open_ends_default_to_full_history(self):
+        halves = split_date_range(None, None)
+        assert halves[0][0] == "1900-01-01"
+        assert halves[1][1] == pd.Timestamp.today().strftime("%Y-%m-%d")
+
+    def test_single_day_cannot_be_split(self):
+        assert split_date_range("2020-01-01", "2020-01-01") is None
+
+
+class TestLinkToQuery:
+    def test_mapped_key_docname(self):
+        query = link_to_query(hudoc_link('{"docname":["turkey"]}'))
+        assert '(docname="turkey") OR (docname:"turkey")' in query
+
+    def test_itemid_link(self):
+        query = link_to_query(hudoc_link('{"itemid":["001-100448"]}'))
+        assert '(itemid="001-100448") OR (itemid:"001-100448")' in query
+
+    def test_kpdate_range(self):
+        query = link_to_query(
+            hudoc_link('{"kpdate":["2020-01-01","2020-12-31"]}')
+        )
+        assert 'kpdate>="2020-01-01" AND kpdate<="2020-12-31"' in query
+
+    def test_kpdate_open_start_defaults_to_1900(self):
+        query = link_to_query(hudoc_link('{"kpdate":["","2020-12-31"]}'))
+        assert 'kpdate>="1900-01-01"' in query
+
+    def test_fulltext_terms(self):
+        query = link_to_query(hudoc_link('{"fulltext":["climate"]}'))
+        assert "(climate)" in query
+
+    def test_languageisocode_filter(self):
+        query = link_to_query(hudoc_link('{"languageisocode":["FRE"]}'))
+        assert '(languageisocode="FRE") OR (languageisocode:"FRE")' in query
+
+    def test_multiple_filters_joined_with_and(self):
+        query = link_to_query(
+            hudoc_link('{"docname":["turkey"],"kpdate":["2020-01-01","2020-12-31"]}')
+        )
+        docname_part = query.index("docname=")
+        kpdate_part = query.index("kpdate>=")
+        assert " AND " in query[docname_part:kpdate_part]
+
+    def test_sort_key_is_ignored(self):
+        query = link_to_query(
+            hudoc_link('{"docname":["turkey"],"sort":["kpdate Descending"]}')
+        )
+        assert "Descending&" not in query.replace("itemid%20Ascending", "")
+        assert '(docname="turkey")' in query
+
+    def test_unmapped_keys_fall_back_to_basic_filter(self):
+        """Regression: article/respondent/etc. filters must be applied.
+
+        These keys are not in query_map; they used to crash (TypeError)
+        after the batching rewrite, and were then silently dropped, which
+        made link-based filtered fetches return the whole database.
+        """
+        query = link_to_query(
+            hudoc_link('{"article":["10"],"respondent":["NLD"]}')
+        )
+        assert '(article="10") OR (article:"10")' in query
+        assert '(respondent="NLD") OR (respondent:"NLD")' in query
+
+    def test_unmapped_violation_and_importance_filters(self):
+        query = link_to_query(
+            hudoc_link('{"violation":["10"],"importance":["1"]}')
+        )
+        assert '(violation="10")' in query
+        assert '(importance="1")' in query
+
+    def test_body_section_filter(self):
+        query = link_to_query(hudoc_link('{"bodylaw":["proportionality"]}'))
+        assert '"THE LAW" ONEAR(n=1000) proportionality' in query
+
+    def test_query_excludes_press_releases(self):
+        query = link_to_query(hudoc_link('{"docname":["turkey"]}'))
+        assert "NOT (doctype=PR OR doctype=HFCOMOLD OR doctype=HECOMOLD)" in query
+
+    def test_placeholders_preserved_for_pagination(self):
+        query = link_to_query(hudoc_link('{"docname":["turkey"]}'))
+        assert "{select}" in query
+        assert "{start}" in query
+        assert "{length}" in query
+
+
+class TestDetermineMetaUrl:
+    def test_query_payload_takes_precedence(self):
+        url = determine_meta_url("some-link", "(contentsitename=ECHR)", None, None)
+        assert "query=(contentsitename=ECHR)" in url
+        assert "{select}" in url and "{start}" in url and "{length}" in url
+
+    def test_link_path_delegates_to_link_to_query(self):
+        link = hudoc_link('{"docname":["turkey"]}')
+        assert determine_meta_url(link, None, None, None) == link_to_query(link)
+
+    def test_default_url_has_language_placeholder_and_collections(self):
+        url = determine_meta_url(None, None, None, None)
+        assert "lang_inputter" in url
+        for collection in ("JUDGMENTS", "COMMUNICATEDCASES", "DECISIONS", "CLIN"):
+            assert f'documentcollectionid2:"{collection}"' in url
+
+    def test_default_url_excludes_press_releases(self):
+        """Regression: press releases (doctype=PR) slipped into default
+        fetches because HUDOC matches PRESS;CHAMBERJUDGMENTS against
+        'JUDGMENTS'. The link path already excluded them."""
+        url = determine_meta_url(None, None, None, None)
+        assert "NOT (doctype=PR OR doctype=HFCOMOLD OR doctype=HECOMOLD)" in url
+
+    def test_default_url_no_dates_has_no_kpdate(self):
+        assert "kpdate" not in determine_meta_url(None, None, None, None)
+
+    def test_default_url_with_date_range(self):
+        url = determine_meta_url(None, None, "2020-01-01", "2020-12-31")
+        assert '(kpdate>="2020-01-01" AND kpdate<="2020-12-31")' in url
+
+    def test_default_url_start_date_only_ends_today(self):
+        url = determine_meta_url(None, None, "2020-01-01", None)
+        assert 'kpdate>="2020-01-01"' in url
+        assert "kpdate<=" in url
+
+    def test_default_url_end_date_only_starts_1900(self):
+        url = determine_meta_url(None, None, None, "2020-12-31")
+        assert 'kpdate>="1900-01-01"' in url
+        assert 'kpdate<="2020-12-31"' in url
+
+
+def fake_response(resultcount, columns_list):
+    """Build a mock requests.Response for the HUDOC results endpoint."""
+    response = MagicMock()
+    response.json.return_value = {
+        "resultcount": resultcount,
+        "results": [{"columns": c} for c in columns_list],
+    }
+    response.raise_for_status.return_value = None
+    return response
+
+
+def make_record(i):
+    return {"itemid": f"001-{i}", "docname": f"CASE {i}", "languageisocode": "ENG"}
+
+
+class TestGetEchrMetadata:
+    """Fetching logic with the HTTP layer mocked out."""
+
+    def run(self, responses, **kwargs):
+        defaults = dict(
+            start_id=0,
+            end_id=None,
+            verbose=False,
+            fields=["itemid", "docname", "languageisocode"],
+            start_date=None,
+            end_date=None,
+            link=None,
+            language=["ENG"],
+            query_payload=None,
+            progress_bar=False,
+        )
+        defaults.update(kwargs)
+        with patch(
+            "echr_extractor.ECHR_metadata_harvester.requests.get",
+            side_effect=responses,
+        ) as mock_get:
+            result = get_echr_metadata(**defaults)
+        return result, mock_get
+
+    def test_returns_dataframe_with_records(self):
+        records = [make_record(i) for i in range(3)]
+        responses = [fake_response(3, []), fake_response(3, records)]
+        df, _ = self.run(responses)
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 3
+        assert list(df["itemid"]) == ["001-0", "001-1", "001-2"]
+
+    def test_returns_false_when_no_results(self):
+        df, _ = self.run([fake_response(0, [])])
+        assert df is False
+
+    def test_returns_false_when_all_requests_fail(self):
+        import requests as requests_module
+
+        def raise_error(*args, **kwargs):
+            raise requests_module.exceptions.ConnectionError("down")
+
+        with patch(
+            "echr_extractor.ECHR_metadata_harvester.requests.get",
+            side_effect=raise_error,
+        ), patch("echr_extractor.ECHR_metadata_harvester.time.sleep"):
+            result = get_echr_metadata(
+                start_id=0,
+                end_id=None,
+                verbose=False,
+                fields=["itemid"],
+                start_date=None,
+                end_date=None,
+                link=None,
+                language=["ENG"],
+                query_payload=None,
+                retry_attempts=0,
+                max_attempts=1,
+                progress_bar=False,
+            )
+        assert result is False
+
+    def test_pagination_respects_batch_size(self):
+        batch1 = [make_record(i) for i in range(2)]
+        batch2 = [make_record(i) for i in range(2, 4)]
+        responses = [
+            fake_response(4, []),
+            fake_response(4, batch1),
+            fake_response(4, batch2),
+        ]
+        df, mock_get = self.run(responses, batch_size=2)
+        assert len(df) == 4
+        urls = [call.args[0] for call in mock_get.call_args_list]
+        assert "start=0&length=2" in urls[1]
+        assert "start=2&length=2" in urls[2]
+
+    def test_end_id_caps_number_of_records(self):
+        records = [make_record(i) for i in range(2)]
+        responses = [fake_response(100, []), fake_response(100, records)]
+        df, mock_get = self.run(responses, end_id=2)
+        urls = [call.args[0] for call in mock_get.call_args_list]
+        assert "start=0&length=2" in urls[1]
+        assert len(df) == 2
+
+    def test_language_filter_in_url(self):
+        responses = [fake_response(1, []), fake_response(1, [make_record(0)])]
+        _, mock_get = self.run(responses, language=["FRE", "GER"])
+        url = mock_get.call_args_list[0].args[0]
+        assert 'languageisocode="FRE"' in url
+        assert 'languageisocode="GER"' in url
+
+    def test_date_filter_in_url(self):
+        responses = [fake_response(1, []), fake_response(1, [make_record(0)])]
+        _, mock_get = self.run(
+            responses, start_date="2023-01-01", end_date="2023-06-30"
+        )
+        url = mock_get.call_args_list[0].args[0]
+        assert "kpdate>=%222023-01-01%22" in url
+        assert "kpdate<=%222023-06-30%22" in url
+
+    def test_date_batching_issues_one_query_per_range(self):
+        responses = [
+            fake_response(1, []),
+            fake_response(1, [make_record(0)]),
+            fake_response(1, []),
+            fake_response(1, [make_record(1)]),
+        ]
+        df, mock_get = self.run(
+            responses,
+            start_date="2020-01-01",
+            end_date="2020-12-31",
+            days_per_batch=200,
+        )
+        assert len(df) == 2
+        urls = [call.args[0] for call in mock_get.call_args_list]
+        assert "2020-01-01" in urls[0] and "2020-07-18" in urls[0]
+        assert "2020-07-19" in urls[2] and "2020-12-31" in urls[2]
+
+    def test_end_id_caps_total_across_date_batches(self):
+        """Regression: end_id/count used to be applied per date batch,
+        so count=10 over 4 batches returned up to 40 records."""
+        records = [make_record(i) for i in range(10)]
+        responses = []
+        for _ in range(4):
+            responses.append(fake_response(100, []))
+            responses.append(fake_response(100, records))
+        df, _ = self.run(
+            responses,
+            end_id=10,
+            start_date="2020-01-01",
+            end_date="2020-12-31",
+            days_per_batch=100,
+        )
+        assert len(df) == 10
+
+    def test_selected_fields_in_url(self):
+        responses = [fake_response(1, []), fake_response(1, [make_record(0)])]
+        _, mock_get = self.run(responses, fields=["itemid", "article"])
+        url = mock_get.call_args_list[0].args[0]
+        assert "select=itemid,article" in url
+
+    def test_over_10k_windows_are_partitioned_automatically(self):
+        """Regression: HUDOC refuses to page past 10,000 results per
+        query (start+length above the cap returns zero rows), so a
+        count above 10k used to silently truncate at exactly 10,000."""
+        big = [make_record(i) for i in range(8000)]
+        small = [make_record(i) for i in range(8000, 12000)]
+        responses = [
+            fake_response(12000, []),   # whole window: over the cap -> split
+            fake_response(8000, []),    # first half fits
+            fake_response(8000, big),
+            fake_response(4000, []),    # second half fits
+            fake_response(4000, small),
+        ]
+        df, mock_get = self.run(responses, batch_size=8000)
+        assert len(df) == 12000
+        assert df["itemid"].is_unique
+        # the split probes carry kpdate bounds
+        assert "kpdate" in mock_get.call_args_list[1].args[0]
+
+    def test_unsplittable_over_10k_query_warns_and_caps(self, caplog):
+        records = [make_record(i) for i in range(10000)]
+        responses = [
+            fake_response(15000, []),
+            fake_response(15000, records),
+        ]
+        link = hudoc_link('{"article":["6"]}')
+        df, mock_get = self.run(responses, link=link, batch_size=10000)
+        assert len(df) == 10000
+        assert "at most 10000" in caplog.text
+        # the fetch never pages past the cap
+        assert "start=0&length=10000" in mock_get.call_args_list[1].args[0]
+
+    def test_link_query_fetches_filtered_results(self):
+        link = hudoc_link('{"article":["10"],"respondent":["NLD"]}')
+        responses = [fake_response(1, []), fake_response(1, [make_record(0)])]
+        df, mock_get = self.run(responses, link=link)
+        url = mock_get.call_args_list[0].args[0]
+        assert "article=%2210%22" in url
+        assert "respondent=%22NLD%22" in url
+        assert len(df) == 1

--- a/tests/test_nodes_edges.py
+++ b/tests/test_nodes_edges.py
@@ -5,7 +5,6 @@ Live end-to-end network construction is covered in test_live_hudoc.py.
 """
 
 import pandas as pd
-import pytest
 
 from echr_extractor.ECHR_nodes_edges_list_transform import (
     echr_nodes_edges,

--- a/tests/test_nodes_edges.py
+++ b/tests/test_nodes_edges.py
@@ -1,0 +1,410 @@
+"""Unit tests for the citation network (nodes/edges) extraction.
+
+These run on synthetic metadata so they are fast and deterministic.
+Live end-to-end network construction is covered in test_live_hudoc.py.
+"""
+
+import pandas as pd
+import pytest
+
+from echr_extractor.ECHR_nodes_edges_list_transform import (
+    echr_nodes_edges,
+    get_casename,
+    get_year_from_ref,
+    retrieve_edges_list,
+)
+
+
+def make_case(
+    itemid,
+    ecli,
+    docname,
+    appno="",
+    lang="ENG",
+    jdate="01/01/2000",
+    scl=None,
+    extractedappno=None,
+):
+    return {
+        "itemid": itemid,
+        "appno": appno,
+        "docname": docname,
+        "ecli": ecli,
+        "languageisocode": lang,
+        "judgementdate": jdate,
+        "scl": scl,
+        "extractedappno": extractedappno,
+    }
+
+
+HENTRICH = make_case(
+    "001-1",
+    "ECLI:CE:ECHR:1994:HENTRICH",
+    "CASE OF HENTRICH v. FRANCE",
+    appno="13616/88",
+    jdate="22/09/1994",
+)
+
+
+def edges_for(cases):
+    df = pd.DataFrame(cases)
+    edges, missing = retrieve_edges_list(df, df)
+    return edges, missing
+
+
+class TestEdgeResolution:
+    def test_reference_by_application_number(self):
+        citing = make_case(
+            "001-2",
+            "ECLI:CITING",
+            "CASE OF AAA v. BELGIUM",
+            appno="100/95",
+            scl="Hentrich v. France, no. 13616/88, 22 September 1994, § 42",
+        )
+        edges, missing = edges_for([HENTRICH, citing])
+
+        assert len(edges) == 1
+        assert edges.iloc[0]["ecli"] == "ECLI:CITING"
+        assert edges.iloc[0]["references"] == ["ECLI:CE:ECHR:1994:HENTRICH"]
+        assert len(missing) == 0
+
+    def test_reference_by_case_name(self):
+        """Regression: docname lookup must be case-consistent.
+
+        The docname index keys are fully uppercased; the lookup text used
+        to re-lowercase "V." so name-based references never resolved and
+        all ended up in missing_references.
+        """
+        citing = make_case(
+            "001-2",
+            "ECLI:CITING",
+            "CASE OF AAA v. BELGIUM",
+            appno="100/95",
+            scl="Hentrich v. France, 22 September 1994, § 42, Series A no. 296-A",
+        )
+        edges, missing = edges_for([HENTRICH, citing])
+
+        assert len(edges) == 1
+        assert edges.iloc[0]["references"] == ["ECLI:CE:ECHR:1994:HENTRICH"]
+        assert len(missing) == 0
+
+    def test_french_reference_by_case_name(self):
+        cited = make_case(
+            "001-1",
+            "ECLI:CITED:FRE",
+            "AFFAIRE HENTRICH c. FRANCE",
+            appno="13616/88",
+            lang="FRE",
+            jdate="22/09/1994",
+        )
+        citing = make_case(
+            "001-2",
+            "ECLI:CITING",
+            "AFFAIRE BBB c. BELGIQUE",
+            appno="100/95",
+            lang="FRE",
+            scl="Hentrich c. France, 22 septembre 1994, § 42",
+        )
+        edges, missing = edges_for([cited, citing])
+
+        assert len(edges) == 1
+        assert edges.iloc[0]["references"] == ["ECLI:CITED:FRE"]
+
+    def test_year_mismatch_is_rejected(self):
+        wrong_year = dict(HENTRICH, jdate="22/09/1980", judgementdate="22/09/1980")
+        citing = make_case(
+            "001-2",
+            "ECLI:CITING",
+            "CASE OF AAA v. BELGIUM",
+            appno="100/95",
+            scl="Hentrich v. France, 22 September 1994, § 42",
+        )
+        edges, missing = edges_for([wrong_year, citing])
+
+        assert len(edges) == 0
+        assert "Hentrich v. France, 22 September 1994, § 42" in list(
+            missing["missing_references"]
+        )
+
+    def test_language_mismatch_is_rejected(self):
+        french_only = dict(HENTRICH, languageisocode="FRE")
+        citing = make_case(
+            "001-2",
+            "ECLI:CITING",
+            "CASE OF AAA v. BELGIUM",
+            appno="100/95",
+            # "v." in the reference implies an English-language citation
+            scl="Hentrich v. France, no. 13616/88, 22 September 1994",
+        )
+        edges, _ = edges_for([french_only, citing])
+
+        assert len(edges) == 0
+
+    def test_multiple_references_aggregated_per_case(self):
+        cited_two = make_case(
+            "001-3",
+            "ECLI:CITED:2",
+            "CASE OF JAMES AND OTHERS v. THE UNITED KINGDOM",
+            appno="8793/79",
+            jdate="21/02/1986",
+        )
+        citing = make_case(
+            "001-2",
+            "ECLI:CITING",
+            "CASE OF AAA v. BELGIUM",
+            appno="100/95",
+            scl=(
+                "Hentrich v. France, no. 13616/88, 22 September 1994;"
+                "James and Others v. the United Kingdom, no. 8793/79, "
+                "21 February 1986"
+            ),
+        )
+        edges, _ = edges_for([HENTRICH, cited_two, citing])
+
+        assert len(edges) == 1
+        assert sorted(edges.iloc[0]["references"]) == [
+            "ECLI:CE:ECHR:1994:HENTRICH",
+            "ECLI:CITED:2",
+        ]
+
+    def test_short_docname_requires_word_boundary(self):
+        """Regression: 'A v. POLAND' must not match every reference whose
+        casename merely ends in '...a v. Poland' (e.g. Bojara v. Poland)."""
+        short_name = make_case(
+            "001-7",
+            "ECLI:SHORT",
+            "A v. POLAND",
+            appno="47023/16",
+            jdate="01/06/2021",
+        )
+        real_cited = make_case(
+            "001-8",
+            "ECLI:BOJARA",
+            "CASE OF BRODA AND BOJARA v. POLAND",
+            appno="26691/18",
+            jdate="29/06/2021",
+        )
+        citing = make_case(
+            "001-2",
+            "ECLI:CITING",
+            "CASE OF AAA v. BELGIUM",
+            appno="100/95",
+            scl="Broda and Bojara v. Poland, 29 June 2021",
+        )
+        edges, _ = edges_for([short_name, real_cited, citing])
+
+        assert len(edges) == 1
+        assert edges.iloc[0]["references"] == ["ECLI:BOJARA"]
+
+    def test_no_scl_produces_no_edges(self):
+        edges, missing = edges_for([HENTRICH])
+        assert len(edges) == 0
+        assert list(edges.columns) == ["ecli", "references"]
+        assert len(missing) == 0
+
+    def test_empty_ecli_falls_back_to_itemid(self):
+        """Regression: cases with an empty-string ECLI (communicated
+        cases, CLIN notes) used to collapse into phantom '' nodes. They
+        must instead be identified by their HUDOC itemid so their
+        citations are preserved."""
+        no_ecli_cited = dict(HENTRICH, ecli="")
+        citing = make_case(
+            "001-2",
+            "ECLI:CITING",
+            "CASE OF AAA v. BELGIUM",
+            appno="100/95",
+            scl="Hentrich v. France, no. 13616/88, 22 September 1994",
+        )
+        no_ecli_citing = dict(citing, ecli="", itemid="001-3", appno="200/95")
+        edges, _ = edges_for([no_ecli_cited, citing, no_ecli_citing])
+
+        assert "" not in set(edges["ecli"])
+        for refs in edges["references"]:
+            assert "" not in refs
+        # The citing case without ECLI is keyed by its itemid
+        assert set(edges["ecli"]) == {"ECLI:CITING", "001-3"}
+        # The cited case without ECLI is referenced by its itemid
+        for refs in edges["references"]:
+            assert refs == ["001-1"]
+
+    def test_no_identifier_at_all_is_dropped(self):
+        citing = make_case(
+            "",
+            "",
+            "CASE OF AAA v. BELGIUM",
+            appno="100/95",
+            scl="Hentrich v. France, no. 13616/88, 22 September 1994",
+        )
+        edges, _ = edges_for([HENTRICH, citing])
+        assert len(edges) == 0
+
+    def test_unresolvable_reference_is_reported_missing(self):
+        citing = make_case(
+            "001-2",
+            "ECLI:CITING",
+            "CASE OF AAA v. BELGIUM",
+            appno="100/95",
+            scl="Nonexistent v. Nowhere, no. 99999/99, 1 January 1999",
+        )
+        edges, missing = edges_for([HENTRICH, citing])
+
+        assert len(edges) == 0
+        assert len(missing) == 1
+
+    def test_self_reference_is_excluded(self):
+        """A case must never appear in its own references (original
+        behavior lost in the batching rewrite)."""
+        case = make_case(
+            "001-1",
+            "ECLI:SELF",
+            "CASE OF SELF v. SELF",
+            appno="1/90",
+            jdate="01/01/1990",
+            scl="Self v. Self, no. 1/90, 1 January 1990",
+        )
+        edges, _ = edges_for([case])
+        assert len(edges) == 0
+
+    def test_document_level_extractedappno_not_blended_into_references(self):
+        """Regression: each scl reference must resolve from its own text.
+        Blending the citing document's extractedappno (every appno
+        mentioned anywhere in its full text) linked each citation to
+        every mentioned case."""
+        unrelated = make_case(
+            "001-9",
+            "ECLI:UNRELATED",
+            "CASE OF UNRELATED v. SPAIN",
+            appno="777/90",
+            jdate="05/05/1994",
+        )
+        citing = make_case(
+            "001-2",
+            "ECLI:CITING",
+            "CASE OF AAA v. BELGIUM",
+            appno="100/95",
+            scl="Hentrich v. France, no. 13616/88, 22 September 1994",
+            # mentions the unrelated case somewhere in its full text
+            extractedappno="777/90;13616/88",
+        )
+        edges, _ = edges_for([HENTRICH, unrelated, citing])
+
+        assert len(edges) == 1
+        assert edges.iloc[0]["references"] == ["ECLI:CE:ECHR:1994:HENTRICH"]
+
+    def test_reference_appno_does_not_match_co_citing_documents(self):
+        """A reference 'no. 13616/88' identifies the case with that
+        application number — not other documents whose extractedappno
+        merely mentions it."""
+        co_citing = make_case(
+            "001-8",
+            "ECLI:COCITING",
+            "CASE OF OTHER v. ITALY",
+            appno="500/90",
+            jdate="22/09/1994",  # same year so the year filter cannot save us
+            extractedappno="13616/88",
+        )
+        citing = make_case(
+            "001-2",
+            "ECLI:CITING",
+            "CASE OF AAA v. BELGIUM",
+            appno="100/95",
+            scl="Hentrich v. France, no. 13616/88, 22 September 1994",
+        )
+        edges, _ = edges_for([HENTRICH, co_citing, citing])
+
+        assert len(edges) == 1
+        assert edges.iloc[0]["references"] == ["ECLI:CE:ECHR:1994:HENTRICH"]
+
+
+class TestEchrNodesEdges:
+    def test_with_dataframe(self):
+        citing = make_case(
+            "001-2",
+            "ECLI:CITING",
+            "CASE OF AAA v. BELGIUM",
+            appno="100/95",
+            scl="Hentrich v. France, no. 13616/88, 22 September 1994",
+        )
+        df = pd.DataFrame([HENTRICH, citing])
+        nodes, edges, missing = echr_nodes_edges(data=df)
+
+        assert len(nodes) == 2
+        assert len(edges) == 1
+        assert len(missing) == 0
+
+    def test_with_metadata_path(self, tmp_path):
+        citing = make_case(
+            "001-2",
+            "ECLI:CITING",
+            "CASE OF AAA v. BELGIUM",
+            appno="100/95",
+            scl="Hentrich v. France, no. 13616/88, 22 September 1994",
+        )
+        path = tmp_path / "metadata.csv"
+        pd.DataFrame([HENTRICH, citing]).to_csv(path, index=False)
+
+        nodes, edges, missing = echr_nodes_edges(metadata_path=str(path))
+
+        assert len(nodes) == 2
+        assert len(edges) == 1
+
+    def test_without_input_returns_empty(self):
+        nodes, edges, missing = echr_nodes_edges()
+        assert nodes == "" and edges == "" and missing == ""
+
+
+class TestLargeSyntheticNetwork:
+    def test_thousand_case_citation_chain(self):
+        """Network construction should scale and stay correct on a larger
+        corpus: 1000 cases where each case cites the previous one."""
+        cases = []
+        for i in range(1000):
+            scl = None
+            if i > 0:
+                scl = f"Case{i - 1:04d} v. France, no. {1000 + i - 1}/90, 1 January 2000"
+            cases.append(
+                make_case(
+                    f"001-{i}",
+                    f"ECLI:{i:04d}",
+                    f"CASE OF CASE{i:04d} v. FRANCE",
+                    appno=f"{1000 + i}/90",
+                    jdate="01/01/2000",
+                    scl=scl,
+                )
+            )
+        edges, missing = edges_for(cases)
+
+        assert len(edges) == 999
+        assert len(missing) == 0
+        # Spot-check a link in the middle of the chain
+        row = edges[edges["ecli"] == "ECLI:0500"].iloc[0]
+        assert row["references"] == ["ECLI:0499"]
+
+
+class TestHelpers:
+    def test_get_casename_english(self):
+        assert (
+            get_casename("Hentrich v. France, 22 September 1994, § 42")
+            == "Hentrich v. France"
+        )
+
+    def test_get_casename_french(self):
+        assert (
+            get_casename("Hentrich c. France, 22 septembre 1994")
+            == "Hentrich c. France"
+        )
+
+    def test_get_casename_comma_in_name(self):
+        assert (
+            get_casename("Federation X, Union Y v. Belgium, 1 January 2000")
+            == "Federation X, Union Y v. Belgium"
+        )
+
+    def test_get_year_from_ref(self):
+        assert get_year_from_ref(["Hentrich v. France", " 22 September 1994"]) == 1994
+
+    def test_get_year_from_ref_no_date(self):
+        assert get_year_from_ref(["Hentrich v. France"]) == 0
+
+    def test_get_year_from_ref_echr_citation(self):
+        assert get_year_from_ref(["Foo v. Bar", " ECHR 2003-IV"]) == 2003

--- a/tests/test_reference_resolver.py
+++ b/tests/test_reference_resolver.py
@@ -1,0 +1,284 @@
+"""Unit tests for citation reference resolution (offline and mocked online)."""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from echr_extractor import (
+    get_document_citations,
+    get_nodes_edges,
+    parse_scl_references,
+    resolve_references,
+)
+from echr_extractor.ECHR_nodes_edges_list_transform import (
+    MISSING_REFERENCE_COLUMNS,
+)
+
+HENTRICH_ROW = {
+    "itemid": "001-57903",
+    "appno": "13616/88",
+    "docname": "CASE OF HENTRICH v. FRANCE",
+    "ecli": "ECLI:CE:ECHR:1994:HENTRICH",
+    "languageisocode": "ENG",
+    "judgementdate": "22/09/1994",
+    "kpdate": "1994-09-22T00:00:00",
+    "doctype": "HEJUD",
+    "doctypebranch": "CHAMBER",
+    "documentcollectionid2": "CASELAW;JUDGMENTS;CHAMBER;ENG",
+}
+
+SCL = (
+    "Hentrich v. France, no. 13616/88, 22 September 1994, § 42;"
+    "Unknown v. Nowhere, no. 99999/99, 1 January 1999"
+)
+
+
+class TestParseSclReferences:
+    def test_one_row_per_reference_with_parsed_fields(self):
+        refs = parse_scl_references(SCL, citing_id="ECLI:CITING")
+        assert list(refs.columns) == MISSING_REFERENCE_COLUMNS
+        assert len(refs) == 2
+        first = refs.iloc[0]
+        assert first["citing_id"] == "ECLI:CITING"
+        assert first["extracted_appnos"] == "13616/88"
+        assert first["casename"] == "Hentrich v. France"
+        assert first["year"] == 1994
+        assert first["ref_language"] == "ENG"
+
+    def test_french_reference_language(self):
+        refs = parse_scl_references("Hentrich c. France, 22 septembre 1994")
+        assert refs.iloc[0]["ref_language"] == "FRE"
+
+    def test_empty_and_nan_scl(self):
+        assert len(parse_scl_references(None)) == 0
+        assert len(parse_scl_references(float("nan"))) == 0
+        assert len(parse_scl_references("")) == 0
+
+
+class TestResolveOffline:
+    def reference_df(self, extra_rows=()):
+        return pd.DataFrame([HENTRICH_ROW, *extra_rows])
+
+    def missing(self, **overrides):
+        row = {
+            "citing_id": "ECLI:CITING",
+            "missing_references": "Hentrich v. France, no. 13616/88, 22 September 1994",
+            "extracted_appnos": "13616/88",
+            "casename": "Hentrich v. France",
+            "year": 1994,
+            "ref_language": "ENG",
+        }
+        row.update(overrides)
+        return pd.DataFrame([row])
+
+    def test_resolves_by_appno(self):
+        resolved, external, still = resolve_references(
+            self.missing(), reference_df=self.reference_df()
+        )
+        assert len(resolved) == 1
+        assert resolved.iloc[0]["resolved_id"] == "ECLI:CE:ECHR:1994:HENTRICH"
+        assert resolved.iloc[0]["match_method"] == "appno"
+        assert list(external["itemid"]) == ["001-57903"]
+        assert len(still) == 0
+
+    def test_resolves_by_casename_when_no_appno(self):
+        resolved, _, still = resolve_references(
+            self.missing(
+                extracted_appnos="",
+                missing_references="Hentrich v. France, 22 September 1994",
+            ),
+            reference_df=self.reference_df(),
+        )
+        assert len(resolved) == 1
+        assert resolved.iloc[0]["match_method"] == "casename"
+
+    def test_year_mismatch_stays_unresolved(self):
+        resolved, _, still = resolve_references(
+            self.missing(year=1980), reference_df=self.reference_df()
+        )
+        assert len(resolved) == 0
+        assert len(still) == 1
+        assert still.iloc[0]["missing_references"].startswith("Hentrich")
+
+    def test_language_mismatch_stays_unresolved(self):
+        resolved, _, still = resolve_references(
+            self.missing(ref_language="FRE"), reference_df=self.reference_df()
+        )
+        assert len(resolved) == 0 and len(still) == 1
+
+    def test_judgment_preferred_over_other_doctypes(self):
+        clin = dict(
+            HENTRICH_ROW,
+            itemid="002-9999",
+            ecli="",
+            doctype="CLIN",
+            documentcollectionid2="CASELAW;CLIN;ENG",
+        )
+        resolved, _, _ = resolve_references(
+            self.missing(), reference_df=self.reference_df([clin])
+        )
+        assert resolved.iloc[0]["resolved_itemid"] == "001-57903"
+        assert resolved.iloc[0]["candidate_count"] == 2
+
+    def test_failed_appno_falls_back_to_casename(self):
+        """A mistyped application number must not prevent resolution when
+        the casename identifies the document (network-builder parity)."""
+        resolved, _, _ = resolve_references(
+            self.missing(
+                extracted_appnos="99999/99",
+                missing_references="Hentrich v. France, no. 99999/99, 22 September 1994",
+            ),
+            reference_df=self.reference_df(),
+        )
+        assert len(resolved) == 1
+        assert resolved.iloc[0]["match_method"] == "casename"
+
+    def test_never_resolves_to_the_citing_document(self):
+        resolved, _, still = resolve_references(
+            self.missing(citing_id="ECLI:CE:ECHR:1994:HENTRICH"),
+            reference_df=self.reference_df(),
+        )
+        assert len(resolved) == 0 and len(still) == 1
+
+    def test_empty_missing_df(self):
+        resolved, external, still = resolve_references(
+            pd.DataFrame(columns=MISSING_REFERENCE_COLUMNS)
+        )
+        assert len(resolved) == 0 and len(external) == 0 and len(still) == 0
+
+
+def hudoc_response(rows):
+    response = MagicMock()
+    response.json.return_value = {
+        "resultcount": len(rows),
+        "results": [{"columns": r} for r in rows],
+    }
+    response.raise_for_status.return_value = None
+    return response
+
+
+class TestResolveOnline:
+    def test_batched_appno_query_resolves(self):
+        missing = pd.DataFrame(
+            [
+                {
+                    "citing_id": "ECLI:CITING",
+                    "missing_references": (
+                        "Hentrich v. France, no. 13616/88, 22 September 1994"
+                    ),
+                    "extracted_appnos": "13616/88",
+                    "casename": "Hentrich v. France",
+                    "year": 1994,
+                    "ref_language": "ENG",
+                }
+            ]
+        )
+        with patch(
+            "echr_extractor.ECHR_metadata_harvester.requests.get",
+            return_value=hudoc_response([HENTRICH_ROW]),
+        ) as mock_get:
+            resolved, external, still = resolve_references(missing)
+
+        assert len(resolved) == 1
+        assert resolved.iloc[0]["resolved_id"] == "ECLI:CE:ECHR:1994:HENTRICH"
+        url = mock_get.call_args_list[0].args[0]
+        assert "appno" in url and "13616/88" in url
+        # press releases are excluded from candidate queries
+        assert "NOT%20(doctype=PR" in url
+
+    def test_second_pass_fetches_docname_candidates_for_failed_appnos(self):
+        """When an appno matches nothing in HUDOC, a second query round
+        must look the reference up by casename."""
+        missing = pd.DataFrame(
+            [
+                {
+                    "citing_id": "ECLI:CITING",
+                    "missing_references": (
+                        "Hentrich v. France, no. 99999/99, 22 September 1994"
+                    ),
+                    "extracted_appnos": "99999/99",
+                    "casename": "Hentrich v. France",
+                    "year": 1994,
+                    "ref_language": "ENG",
+                }
+            ]
+        )
+        responses = [
+            hudoc_response([]),              # appno query: nothing
+            hudoc_response([HENTRICH_ROW]),  # docname retry: found
+        ]
+        with patch(
+            "echr_extractor.ECHR_metadata_harvester.requests.get",
+            side_effect=responses,
+        ) as mock_get:
+            resolved, _, still = resolve_references(missing)
+
+        assert len(resolved) == 1
+        assert resolved.iloc[0]["match_method"] == "casename"
+        assert len(still) == 0
+        retry_url = mock_get.call_args_list[1].args[0]
+        assert "docname" in retry_url
+
+
+class TestGetNodesEdgesResolution:
+    def corpus(self):
+        citing = {
+            "itemid": "001-2",
+            "appno": "100/95",
+            "docname": "CASE OF AAA v. BELGIUM",
+            "ecli": "ECLI:CITING",
+            "languageisocode": "ENG",
+            "judgementdate": "01/01/2000",
+            "extractedappno": None,
+            "scl": "Hentrich v. France, no. 13616/88, 22 September 1994",
+        }
+        return pd.DataFrame([citing])
+
+    def test_reference_df_resolution_adds_external_edges_and_nodes(self):
+        nodes, edges, missing = get_nodes_edges(
+            df=self.corpus(),
+            save_file="n",
+            reference_df=pd.DataFrame([HENTRICH_ROW]),
+        )
+        assert len(missing) == 0
+        assert len(edges) == 1
+        assert edges.iloc[0]["ecli"] == "ECLI:CITING"
+        assert edges.iloc[0]["references"] == ["ECLI:CE:ECHR:1994:HENTRICH"]
+        assert "in_corpus" in nodes.columns
+        assert len(nodes) == 2
+        external = nodes[~nodes["in_corpus"]]
+        assert list(external["itemid"]) == ["001-57903"]
+
+    def test_without_resolution_shape_is_unchanged(self):
+        nodes, edges, missing = get_nodes_edges(df=self.corpus(), save_file="n")
+        assert "in_corpus" not in nodes.columns
+        assert len(edges) == 0
+        assert len(missing) == 1
+        assert missing.iloc[0]["extracted_appnos"] == "13616/88"
+
+
+class TestGetDocumentCitations:
+    def test_in_memory_document_without_resolution(self):
+        result = get_document_citations(
+            document={"itemid": "001-2", "ecli": "ECLI:X", "scl": SCL},
+            resolve=False,
+        )
+        assert len(result) == 2
+        assert result.iloc[0]["citing_id"] == "ECLI:X"
+
+    def test_in_memory_document_with_offline_resolution(self):
+        result = get_document_citations(
+            document={"itemid": "001-2", "ecli": "ECLI:X", "scl": SCL},
+            reference_df=pd.DataFrame([HENTRICH_ROW]),
+        )
+        assert len(result) == 2
+        resolved = result[result["resolved_id"].notna()]
+        assert len(resolved) == 1
+        assert resolved.iloc[0]["resolved_docname"] == "CASE OF HENTRICH v. FRANCE"
+        unresolved = result[result["resolved_id"].isna()]
+        assert unresolved.iloc[0]["missing_references"].startswith("Unknown")
+
+    def test_requires_itemid_or_document(self):
+        with pytest.raises(ValueError):
+            get_document_citations()


### PR DESCRIPTION
## Fixes

**Metadata fetching**
- HUDOC links with unmapped filter keys (`article`, `respondent`, `violation`, ...) were silently dropping those filters and fetching the whole database; they now apply as basic field filters.
- `count`/`end_id` caps the total across date batches (used to over-fetch per batch), and single-day / final-day date ranges are no longer lost.
- HUDOC refuses to page past 10,000 results per query, so larger fetches silently truncated at exactly 10k; queries are now bisected into date windows automatically (verified live: `count=10500` returns 10,500; partitioned and single-query fetches of the same window are identical).
- The default query now excludes press releases, matching the link path.

**Citation network**
- Name-based reference lookup could never match (case-inconsistent with its index) and short docnames like *A v. Poland* matched inside every `...a v. Poland` casename; both fixed.
- Each `scl` reference now resolves only from its own text: blending the citing document's `extractedappno` produced ~26.5k false references on a one-year corpus (~0 legitimate, measured). Self-references are excluded again.
- Documents without an ECLI (communicated cases, CLIN notes) are identified by their itemid instead of collapsing into a phantom empty-string node.
- `dateparser` memoization cuts edge calculation on a 900-case corpus from 104s to 2.8s with identical output.

**Robustness**
- Full-text downloader no longer stores error pages as document text, and warns about failed or empty (HTTP 204) downloads instead of dropping them silently.
- `get_echr_extra(count=N)` saves files named `0-N` like `get_echr`; `prepare_echr_corpus` preserves all metadata columns as documented.

## External reference resolution

The network is self-enclosed: edges only point at documents inside the corpus. Out-of-corpus citations are now reported as a structured table (citing document, reference text, parsed appnos/casename/year/language) and can be resolved to real HUDOC documents:

- `get_nodes_edges(..., resolve_external=True)` or `reference_df=<larger corpus>` (offline) — resolved targets join the edges, their metadata joins the nodes with `in_corpus=False`, and unresolvable references are returned unchanged.
- `get_document_citations(itemid=...)` — the full resolved out-citation list of a single document (also `echr-extractor citations --itemid ...`).

## Testing

- 325 unit tests (HTTP mocked) and 14 opt-in live HUDOC tests (`pytest --run-live`), including semantic checks that every edge traces back to the citing text. Coverage 46% → 82%.
- All README examples were executed against live HUDOC; broken ones (compound `query_payload`, saved-file paths) were corrected.