### PR TITLE
Unify citation matching between network builder and resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,11 @@ directly:
   (including the missing-references output of `get_nodes_edges()`) and returns
   `(resolved, external_nodes, still_missing)`. With `reference_df` it works
   fully offline; without it, HUDOC is queried in batches. References are tried
-  by application number first, then by casename
+  by application number first, then by casename. `missing_df` must contain all
+  of the columns `citing_id`, `missing_references`, `extracted_appnos`,
+  `casename`, `year` and `ref_language` (a `ValueError` is raised otherwise) —
+  build it with `parse_scl_references()` or `get_nodes_edges()` rather than by
+  hand
 
 ### `get_echr_segments()` - Segment Full Texts
 

--- a/src/echr_extractor/ECHR_metadata_harvester.py
+++ b/src/echr_extractor/ECHR_metadata_harvester.py
@@ -476,6 +476,11 @@ def get_echr_metadata(
     can_partition = not link and not query_payload
     pending_ranges = list(date_ranges)
     batch_idx = 0
+    # start_id offsets the first window that could actually contribute
+    # records: windows with resultcount == 0 carry it forward (there is
+    # nothing to skip in them), but a FAILED window consumes it — its
+    # results may well exist, and applying start_id to a later window
+    # would silently drop records that were never meant to be skipped.
     first_fetch = True
 
     while pending_ranges:
@@ -514,6 +519,7 @@ def get_echr_metadata(
             logging.error(f"Failed to get result count for batch {batch_idx + 1}")
             total_failed += 1
             batch_idx += 1
+            first_fetch = False
             continue
 
         try:
@@ -524,6 +530,7 @@ def get_echr_metadata(
             logging.error(f"Failed to parse result count: {e}")
             total_failed += 1
             batch_idx += 1
+            first_fetch = False
             continue
 
         if resultcount == 0:

--- a/src/echr_extractor/ECHR_nodes_edges_list_transform.py
+++ b/src/echr_extractor/ECHR_nodes_edges_list_transform.py
@@ -91,6 +91,143 @@ def node_identifier(ecli, itemid):
     return None
 
 
+def split_scl_references(scl):
+    """Split a raw ``scl`` citation string into cleaned reference strings.
+
+    Shared by the network builder and the reference resolver so both
+    always see the same set of references for a given document.
+    """
+    if scl is None or (isinstance(scl, float) and pd.isna(scl)):
+        return []
+    refs = []
+    for ref in str(scl).split(";"):
+        ref = re.sub("\n", "", ref).strip()
+        if ref:
+            refs.append(ref)
+    return refs
+
+
+def parse_reference(ref, citing_id=None):
+    """Parse one scl citation into its components.
+
+    Returns a dict with the MISSING_REFERENCE_COLUMNS keys: the
+    application numbers found in the reference text itself, the
+    casename, the judgment year (None when absent) and the citation
+    language ("v." marks English case names, "c." French ones).
+
+    Only application numbers from the reference text are extracted here.
+    The citing document's extractedappno list must NOT be blended in: it
+    contains every application number mentioned anywhere in the full
+    text, so using it per reference links each citation to every case
+    the document mentions.
+    """
+    appnos = [x.strip() for x in re.findall(r"[0-9]{3,5}\/[0-9]{2}", ref) if x.strip()]
+    casename = str(get_casename(ref) or "").strip()
+    year = get_year_from_ref(ref.split(","))
+    return {
+        "citing_id": citing_id,
+        "missing_references": ref,
+        "extracted_appnos": ";".join(appnos),
+        "casename": casename,
+        "year": year if year > 0 else None,
+        # "v." marks an English case name, "c." a French one. Detect on
+        # the parsed casename rather than the text before the first
+        # comma: reporter prefixes ("Eur. Court H.R., X v. Y ...") and
+        # commas inside the case name would otherwise hide the "v." and
+        # misclassify the reference as French. Old-style citations
+        # ("Eur. Court H.R. X judgment of ...") contain neither marker;
+        # their language is unknown ("") and the language filter lets
+        # both sides through.
+        "ref_language": _reference_language(casename),
+    }
+
+
+def _reference_language(casename):
+    if "v." in casename:
+        return "ENG"
+    if "c." in casename:
+        return "FRE"
+    return ""
+
+
+def normalize_casename(casename):
+    """Normalize a parsed casename for docname-index lookup.
+
+    The docname index keys are fully uppercased, so the lookup text must
+    stay uppercase too (no "V." -> "v." style case flips, or the
+    word-boundary comparison in find_docname_positions can never match).
+    Old-style citations ("Eur. Court H.R. X judgment of 27 October
+    1975") carry reporter and date boilerplate that docnames never
+    contain; the clean_pattern regexes strip it, and any stray commas
+    the stripped boilerplate leaves at the edges are trimmed as well.
+    """
+    uptext = str(casename).upper()
+    if "BV" in uptext:
+        uptext = uptext.replace("BV", "B.V.")
+    for pattern in clean_pattern:
+        uptext = re.sub(pattern, "", uptext)
+    uptext = re.sub(r"\[.*", "", uptext)
+    return uptext.strip(" ,")
+
+
+def find_docname_positions(uptext, docname_index, max_matches=None):
+    """Word-boundary docname lookup shared by builder and resolver.
+
+    Tries an exact index hit first, then falls back to substring
+    containment aligned on word boundaries: short names like
+    "A v. POLAND" must not match inside every "...a v. Poland"-suffixed
+    docname. ``max_matches`` caps the fallback scan on large corpora.
+    """
+    positions = set()
+    if not uptext:
+        return positions
+    if uptext in docname_index:
+        positions.update(docname_index[uptext])
+        return positions
+    padded_uptext = f" {uptext} "
+    matches_found = 0
+    for docname, docname_positions in docname_index.items():
+        padded_docname = f" {docname} "
+        if padded_uptext in padded_docname or padded_docname in padded_uptext:
+            positions.update(docname_positions)
+            matches_found += len(docname_positions)
+            if max_matches is not None and matches_found > max_matches:
+                break
+    return positions
+
+
+def candidate_year(judgementdate, kpdate=None):
+    """Year a candidate document was delivered, for the year filter.
+
+    Prefers judgementdate and falls back to kpdate (decisions and
+    communicated cases often carry only the latter). Returns None when
+    neither value parses as a date.
+    """
+    for value in (judgementdate, kpdate):
+        if pd.notna(value) and str(value).strip():
+            try:
+                date = parse_date_cached(str(value))
+            except (ValueError, TypeError):
+                continue
+            if date:
+                return date.year
+    return None
+
+
+def passes_reference_filters(cand_lang, cand_year, ref_lang, ref_year):
+    """Language/year candidate filter shared by builder and resolver.
+
+    A candidate survives when its language list contains the reference's
+    language and its year equals the reference's year; a missing value
+    on either side of a comparison lets the candidate through.
+    """
+    if ref_lang and cand_lang and ref_lang not in cand_lang:
+        return False
+    if cand_year and pd.notna(ref_year) and ref_year and cand_year != int(ref_year):
+        return False
+    return True
+
+
 def retrieve_edges_list(df, df_unfiltered):
     """
     OPTIMIZED VERSION: Returns a dataframe consisting of 2 columns 'ecli' and 'references' which
@@ -125,19 +262,16 @@ def retrieve_edges_list(df, df_unfiltered):
                     docname_index[docname] = []
                 docname_index[docname].append(idx)
 
-    # Pre-parse dates and years
+    # Pre-parse judgment years. The cache is exhaustive: it is built
+    # from the same judgementdate values a per-reference re-parse would
+    # see (parse_date_cached is memoized), so there is no fallback
+    # parsing at filter time.
     logging.info("Pre-parsing dates...")
-    date_cache = {}
     year_cache = {}
     for idx, row in df_unfiltered.iterrows():
-        if pd.notna(row.judgementdate):
-            try:
-                date = parse_date_cached(str(row.judgementdate))
-                if date:
-                    date_cache[idx] = date
-                    year_cache[idx] = date.year
-            except (ValueError, TypeError):
-                pass
+        year = candidate_year(row.judgementdate, getattr(row, "kpdate", None))
+        if year:
+            year_cache[idx] = year
 
     # Pre-store language codes
     lang_cache = {}
@@ -157,7 +291,7 @@ def retrieve_edges_list(df, df_unfiltered):
     logging.info("Indexes created:")
     logging.info(f"  - Appno index: {len(appno_index)} entries")
     logging.info(f"  - Docname index: {len(docname_index)} entries")
-    logging.info(f"  - Date cache: {len(date_cache)} entries")
+    logging.info(f"  - Year cache: {len(year_cache)} entries")
 
     # Now process edges with fast lookups
     edges_list = []  # Collect edges in list, then convert to DataFrame at end
@@ -179,24 +313,12 @@ def retrieve_edges_list(df, df_unfiltered):
         citing_id = node_identifier(item.ecli, getattr(item, "itemid", None))
 
         if pd.notna(item.scl):
-            ref_list = str(item.scl).split(";")
-            new_ref_list = []
-            for ref in ref_list:
-                ref = re.sub("\n", "", ref).strip()
-                if ref:
-                    new_ref_list.append(ref)
-
+            new_ref_list = split_scl_references(item.scl)
             tot_num_refs += len(new_ref_list)
 
             for ref in new_ref_list:
-                # Extract application numbers from the reference text
-                # itself. The citing document's extractedappno list must
-                # NOT be blended in here: it contains every application
-                # number mentioned anywhere in the full text, so using it
-                # per reference links each citation to every case the
-                # document mentions.
-                app_numbers = re.findall(r"[0-9]{3,5}\/[0-9]{2}", ref)
-                app_numbers = [x.strip() for x in app_numbers if x.strip()]
+                parsed = parse_reference(ref, citing_id)
+                app_numbers = [a for a in parsed["extracted_appnos"].split(";") if a]
 
                 # Find matching cases
                 candidate_indices = set()
@@ -210,83 +332,25 @@ def retrieve_edges_list(df, df_unfiltered):
                         if appno in appno_index:
                             candidate_indices.update(appno_index[appno])
 
-                # If no matches, try by casename
-                if not candidate_indices:
-                    casename = get_casename(ref)
-                    if casename:
-                        # Normalize casename for lookup. The docname index keys
-                        # are fully uppercased, so the lookup text must stay
-                        # uppercase too (no "V." -> "v." style case flips, or
-                        # the substring comparison below can never match).
-                        patterns = clean_pattern
-                        uptext = casename.upper()
-
-                        if "BV" in uptext:
-                            uptext = uptext.replace("BV", "B.V.")
-
-                        for pattern in patterns:
-                            uptext = re.sub(pattern, "", uptext)
-
-                        uptext = re.sub(r"\[.*", "", uptext)
-                        uptext = uptext.strip()
-
-                        # Try exact match first
-                        if uptext in docname_index:
-                            candidate_indices.update(docname_index[uptext])
-                        else:
-                            # Try partial match (only if needed - this is
-                            # slower). The containment must align on word
-                            # boundaries: short names like "A v. POLAND"
-                            # would otherwise match inside every
-                            # "...a v. Poland"-suffixed docname.
-                            padded_uptext = f" {uptext} "
-                            matches_found = 0
-                            for docname, indices in docname_index.items():
-                                padded_docname = f" {docname} "
-                                if (
-                                    padded_uptext in padded_docname
-                                    or padded_docname in padded_uptext
-                                ):
-                                    candidate_indices.update(indices)
-                                    matches_found += len(indices)
-                                    if matches_found > 100:  # Limit to prevent slowdown
-                                        break
+                # If no matches, try by casename (capped to prevent the
+                # partial-match scan from slowing large corpora down)
+                if not candidate_indices and parsed["casename"]:
+                    candidate_indices = find_docname_positions(
+                        normalize_casename(parsed["casename"]),
+                        docname_index,
+                        max_matches=100,
+                    )
 
                 # Filter candidates by language and year
-                components = ref.split(",")
-                year_from_ref = get_year_from_ref(components)
-
-                # Determine language from reference
-                if "v." in components[0]:
-                    ref_lang = "ENG"
-                else:
-                    ref_lang = "FRE"
-
-                # Filter candidates
                 final_candidates = []
                 for idx in candidate_indices:
-                    # Filter by language
-                    if idx in lang_cache:
-                        case_lang = lang_cache[idx]
-                        if ref_lang not in case_lang:
-                            continue
-
-                    # Filter by year
-                    if year_from_ref > 0 and idx in year_cache:
-                        if year_cache[idx] != year_from_ref:
-                            continue
-                    elif year_from_ref > 0:
-                        # If no cached year, try parsing
-                        try:
-                            if idx in df_unfiltered.index:
-                                row = df_unfiltered.loc[idx]
-                                if pd.notna(row.judgementdate):
-                                    date = parse_date_cached(str(row.judgementdate))
-                                    if date and date.year != year_from_ref:
-                                        continue
-                        except (ValueError, TypeError, AttributeError):
-                            continue
-
+                    if not passes_reference_filters(
+                        lang_cache.get(idx),
+                        year_cache.get(idx),
+                        parsed["ref_language"],
+                        parsed["year"],
+                    ):
+                        continue
                     # Add ECLI if available
                     if idx in ecli_cache:
                         final_candidates.append(ecli_cache[idx])
@@ -295,16 +359,7 @@ def retrieve_edges_list(df, df_unfiltered):
                     eclis.update(final_candidates)
                 else:
                     count += 1
-                    missing_cases.append(
-                        {
-                            "citing_id": citing_id,
-                            "missing_references": ref,
-                            "extracted_appnos": ";".join(app_numbers),
-                            "casename": str(get_casename(ref) or "").strip(),
-                            "year": year_from_ref if year_from_ref > 0 else None,
-                            "ref_language": ref_lang,
-                        }
-                    )
+                    missing_cases.append(parsed)
 
             # Add edges for this case, keyed by ECLI or itemid fallback.
             # A case must not reference itself (original behavior).

--- a/src/echr_extractor/ECHR_reference_resolver.py
+++ b/src/echr_extractor/ECHR_reference_resolver.py
@@ -15,17 +15,19 @@ dropped.
 """
 
 import logging
-import re
 
 import pandas as pd
 
 from .ECHR_metadata_harvester import basic_function, get_r
 from .ECHR_nodes_edges_list_transform import (
     MISSING_REFERENCE_COLUMNS,
-    get_casename,
-    get_year_from_ref,
+    candidate_year,
+    find_docname_positions,
     node_identifier,
-    parse_date_cached,
+    normalize_casename,
+    parse_reference,
+    passes_reference_filters,
+    split_scl_references,
 )
 
 RESOLVER_FIELDS = [
@@ -58,45 +60,17 @@ def parse_scl_references(scl, citing_id=None):
     """Parse an scl citation string into one row per reference.
 
     Returns a DataFrame with MISSING_REFERENCE_COLUMNS, the same shape
-    as the missing-references table produced by the network builder.
+    as the missing-references table produced by the network builder
+    (both are built from the same shared parsing helpers).
     """
-    rows = []
-    if scl is None or (isinstance(scl, float) and pd.isna(scl)):
-        return pd.DataFrame(columns=MISSING_REFERENCE_COLUMNS)
-    for ref in str(scl).split(";"):
-        ref = re.sub("\n", "", ref).strip()
-        if not ref:
-            continue
-        appnos = [
-            x.strip()
-            for x in re.findall(r"[0-9]{3,5}\/[0-9]{2}", ref)
-            if x.strip()
-        ]
-        components = ref.split(",")
-        year = get_year_from_ref(components)
-        rows.append(
-            {
-                "citing_id": citing_id,
-                "missing_references": ref,
-                "extracted_appnos": ";".join(appnos),
-                "casename": str(get_casename(ref) or "").strip(),
-                "year": year if year > 0 else None,
-                "ref_language": "ENG" if "v." in components[0] else "FRE",
-            }
-        )
+    rows = [
+        parse_reference(ref, citing_id) for ref in split_scl_references(scl)
+    ]
     if not rows:
         return pd.DataFrame(columns=MISSING_REFERENCE_COLUMNS)
     return pd.DataFrame(rows).drop_duplicates(
         subset=["citing_id", "missing_references"]
     ).reset_index(drop=True)
-
-
-def _normalize_casename(casename):
-    uptext = str(casename).upper()
-    if "BV" in uptext:
-        uptext = uptext.replace("BV", "B.V.")
-    uptext = re.sub(r"\[.*", "", uptext)
-    return uptext.strip()
 
 
 def _fetch_candidates(query, timeout, retry_attempts, max_attempts, verbose):
@@ -145,7 +119,14 @@ def _candidate_pool_online(
         if row_appnos:
             appnos.update(row_appnos)
         elif str(row["casename"] or "").strip():
-            casenames.add(str(row["casename"]).strip())
+            # Query HUDOC with the NORMALIZED casename: raw old-style
+            # citations carry reporter/date boilerplate ("Eur. Court
+            # H.R. X judgment of ...") that no docname contains, so the
+            # raw string would fetch nothing and the target could never
+            # enter the candidate pool.
+            normalized = normalize_casename(row["casename"])
+            if normalized:
+                casenames.add(normalized)
 
     candidates = []
     appno_list = sorted(appnos)
@@ -176,17 +157,17 @@ def _index_pool(pool):
     appno_index, docname_index = {}, {}
     rows = []
     for _, row in pool.iterrows():
-        ident = node_identifier(row.get("ecli"), row.get("itemid"))
+        # Rows without a usable itemid (user reference_df with NaN
+        # itemids) must be skipped outright: their itemid would
+        # stringify to "nan" and create phantom external nodes.
+        itemid = row.get("itemid")
+        itemid = "" if pd.isna(itemid) else str(itemid).strip()
+        if not itemid or itemid.lower() == "nan":
+            continue
+        ident = node_identifier(row.get("ecli"), itemid)
         if not ident:
             continue
-        year = None
-        for date_col in ("judgementdate", "kpdate"):
-            value = row.get(date_col)
-            if pd.notna(value) and str(value).strip():
-                date = parse_date_cached(str(value))
-                if date:
-                    year = date.year
-                    break
+        year = candidate_year(row.get("judgementdate"), row.get("kpdate"))
         lang = (
             str(row.get("languageisocode")).upper()
             if pd.notna(row.get("languageisocode"))
@@ -199,7 +180,7 @@ def _index_pool(pool):
         )
         entry = {
             "ident": ident,
-            "itemid": str(row.get("itemid") or ""),
+            "itemid": itemid,
             "docname": str(row.get("docname") or ""),
             "year": year,
             "lang": lang,
@@ -220,17 +201,14 @@ def _index_pool(pool):
 
 
 def _filter_candidates(positions, entries, row):
-    year = row["year"]
     ref_lang = str(row["ref_language"] or "")
-    survivors = []
-    for pos in positions:
-        entry = entries[pos]
-        if ref_lang and entry["lang"] and ref_lang not in entry["lang"]:
-            continue
-        if pd.notna(year) and year and entry["year"] and entry["year"] != int(year):
-            continue
-        survivors.append(entry)
-    return survivors
+    return [
+        entries[pos]
+        for pos in positions
+        if passes_reference_filters(
+            entries[pos]["lang"], entries[pos]["year"], ref_lang, row["year"]
+        )
+    ]
 
 
 def _match_reference(row, entries, appno_index, docname_index):
@@ -252,17 +230,10 @@ def _match_reference(row, entries, appno_index, docname_index):
         method = "appno"
 
     if not survivors:
-        uptext = _normalize_casename(row["casename"])
+        uptext = normalize_casename(row["casename"])
         if not uptext:
             return None, method if appnos else "none", 0
-        positions = set()
-        if uptext in docname_index:
-            positions.update(docname_index[uptext])
-        else:
-            padded_up = f" {uptext} "
-            for docname, pos_list in docname_index.items():
-                if padded_up in f" {docname} " or f" {docname} " in padded_up:
-                    positions.update(pos_list)
+        positions = find_docname_positions(uptext, docname_index)
         casename_survivors = _filter_candidates(positions, entries, row)
         if casename_survivors:
             survivors, method = casename_survivors, "casename"
@@ -270,7 +241,17 @@ def _match_reference(row, entries, appno_index, docname_index):
     if not survivors:
         return None, method, 0
     # Deterministic best: prefer judgments, then stable itemid order
-    survivors.sort(key=lambda e: (not e["is_judgment"], e["itemid"]))
+    # Deterministic best: prefer judgments, then original-language
+    # documents (translations carry a "[<language> Translation]" docname
+    # suffix and a non-ENG/FRE language code), then stable itemid order.
+    survivors.sort(
+        key=lambda e: (
+            not e["is_judgment"],
+            e["lang"] not in ("ENG", "FRE"),
+            "TRANSLATION" in e["docname"].upper(),
+            e["itemid"],
+        )
+    )
     return survivors[0], method, len(survivors)
 
 
@@ -315,10 +296,15 @@ def resolve_references(
     """Resolve unresolved citation references to real HUDOC documents.
 
     :param pd.DataFrame missing_df: Missing-references table from
-        get_nodes_edges() (or parse_scl_references()).
+        get_nodes_edges() (or parse_scl_references()). It must contain
+        all MISSING_REFERENCE_COLUMNS: citing_id, missing_references,
+        extracted_appnos, casename, year and ref_language; a ValueError
+        is raised otherwise. Build it with parse_scl_references() rather
+        than by hand.
     :param pd.DataFrame reference_df: Optional metadata DataFrame to
         resolve against offline. When omitted, HUDOC is queried with
-        batched application-number and casename lookups.
+        batched application-number and casename lookups. Rows without a
+        usable itemid are ignored.
     :return: tuple (resolved_df, external_nodes_df, still_missing_df).
         resolved_df has RESOLVED_COLUMNS; external_nodes_df holds one
         metadata row per distinct resolved document; still_missing_df
@@ -329,6 +315,19 @@ def resolve_references(
             pd.DataFrame(columns=RESOLVED_COLUMNS),
             pd.DataFrame(columns=RESOLVER_FIELDS),
             pd.DataFrame(columns=MISSING_REFERENCE_COLUMNS),
+        )
+
+    missing_columns = [
+        column
+        for column in MISSING_REFERENCE_COLUMNS
+        if column not in missing_df.columns
+    ]
+    if missing_columns:
+        raise ValueError(
+            f"missing_df lacks required column(s) {missing_columns}; "
+            f"resolve_references expects all of {MISSING_REFERENCE_COLUMNS}, "
+            "as produced by parse_scl_references() or the "
+            "missing-references table of get_nodes_edges()."
         )
 
     if reference_df is not None:
@@ -354,11 +353,11 @@ def resolve_references(
         retry_df = pd.DataFrame(still_missing_rows)
         retry_names = sorted(
             {
-                str(name).strip()
+                normalize_casename(name)
                 for name, appnos in zip(
                     retry_df["casename"], retry_df["extracted_appnos"]
                 )
-                if str(name or "").strip() and str(appnos or "").strip()
+                if normalize_casename(name) and str(appnos or "").strip()
             }
         )
         extra = []
@@ -371,14 +370,25 @@ def resolve_references(
                 )
             )
         if extra:
-            pool = pd.concat(
-                [pool, pd.DataFrame(extra)], ignore_index=True
-            ).drop_duplicates(subset=["itemid"]).reset_index(drop=True)
-            retry_resolved, still_missing_rows, retry_itemids = _match_rows(
-                retry_df, pool
+            # Match the retry rows against the newly fetched documents
+            # only: everything already in the pool was tried (and
+            # rejected) in the first pass, so re-indexing it would be
+            # wasted work.
+            extra_df = (
+                pd.DataFrame(extra)
+                .drop_duplicates(subset=["itemid"])
+                .reset_index(drop=True)
             )
-            resolved_rows.extend(retry_resolved)
-            resolved_itemids |= retry_itemids
+            extra_df = extra_df[
+                ~extra_df["itemid"].isin(pool["itemid"])
+            ].reset_index(drop=True)
+            if len(extra_df):
+                retry_resolved, still_missing_rows, retry_itemids = (
+                    _match_rows(retry_df, extra_df)
+                )
+                resolved_rows.extend(retry_resolved)
+                resolved_itemids |= retry_itemids
+                pool = pd.concat([pool, extra_df], ignore_index=True)
 
     resolved_df = (
         pd.DataFrame(resolved_rows)

--- a/tests/test_metadata_harvester.py
+++ b/tests/test_metadata_harvester.py
@@ -362,6 +362,52 @@ class TestGetEchrMetadata:
         )
         assert len(df) == 10
 
+    def test_start_id_not_applied_to_later_batch_after_failure(self):
+        """Regression: when the first date window FAILS, start_id must
+        be consumed rather than shifted onto the next window — that
+        window's records were never meant to be skipped."""
+        import requests as requests_module
+
+        records = [make_record(i) for i in range(3)]
+        responses = [
+            requests_module.exceptions.ConnectionError("down"),  # window 1
+            fake_response(3, []),  # window 2 count
+            fake_response(3, records),  # window 2 fetch
+        ]
+        df, mock_get = self.run(
+            responses,
+            start_id=2,
+            start_date="2020-01-01",
+            end_date="2020-12-31",
+            days_per_batch=200,
+            retry_attempts=0,
+            max_attempts=1,
+        )
+        assert len(df) == 3
+        fetch_url = mock_get.call_args_list[-1].args[0]
+        assert "start=0&" in fetch_url
+
+    def test_start_id_carries_past_empty_windows(self):
+        """A window with zero results does not consume start_id: there
+        is nothing in it to skip, so the offset applies to the first
+        window that actually has results."""
+        records = [make_record(i) for i in range(2, 5)]
+        responses = [
+            fake_response(0, []),  # window 1: empty
+            fake_response(5, []),  # window 2 count
+            fake_response(3, records),  # window 2 fetch from index 2
+        ]
+        df, mock_get = self.run(
+            responses,
+            start_id=2,
+            start_date="2020-01-01",
+            end_date="2020-12-31",
+            days_per_batch=200,
+        )
+        assert len(df) == 3
+        fetch_url = mock_get.call_args_list[-1].args[0]
+        assert "start=2&" in fetch_url
+
     def test_selected_fields_in_url(self):
         responses = [fake_response(1, []), fake_response(1, [make_record(0)])]
         _, mock_get = self.run(responses, fields=["itemid", "article"])

--- a/tests/test_nodes_edges.py
+++ b/tests/test_nodes_edges.py
@@ -10,6 +10,7 @@ from echr_extractor.ECHR_nodes_edges_list_transform import (
     echr_nodes_edges,
     get_casename,
     get_year_from_ref,
+    normalize_casename,
     retrieve_edges_list,
 )
 
@@ -108,6 +109,25 @@ class TestEdgeResolution:
 
         assert len(edges) == 1
         assert edges.iloc[0]["references"] == ["ECLI:CITED:FRE"]
+
+    def test_old_style_reference_by_case_name(self):
+        """Old-style 'Eur. Court H.R. ... judgment of <date>' citations
+        must have their boilerplate stripped before docname lookup."""
+        citing = make_case(
+            "001-2",
+            "ECLI:CITING",
+            "CASE OF AAA v. BELGIUM",
+            appno="100/95",
+            scl=(
+                "Eur. Court H.R. Hentrich v. France judgment of "
+                "22 September 1994, Series A no. 296-A"
+            ),
+        )
+        edges, missing = edges_for([HENTRICH, citing])
+
+        assert len(edges) == 1
+        assert edges.iloc[0]["references"] == ["ECLI:CE:ECHR:1994:HENTRICH"]
+        assert len(missing) == 0
 
     def test_year_mismatch_is_rejected(self):
         wrong_year = dict(HENTRICH, jdate="22/09/1980", judgementdate="22/09/1980")
@@ -407,3 +427,24 @@ class TestHelpers:
 
     def test_get_year_from_ref_echr_citation(self):
         assert get_year_from_ref(["Foo v. Bar", " ECHR 2003-IV"]) == 2003
+
+    def test_normalize_casename_strips_reporter_boilerplate(self):
+        assert (
+            normalize_casename(
+                "Eur. Court H.R. Hentrich v. France judgment of "
+                "22 September 1994"
+            )
+            == "HENTRICH V. FRANCE"
+        )
+
+    def test_normalize_casename_strips_stray_commas(self):
+        assert (
+            normalize_casename(
+                "Eur. Court H.R., Hentrich v. France judgment of "
+                "22 September 1994"
+            )
+            == "HENTRICH V. FRANCE"
+        )
+
+    def test_normalize_casename_plain_name_only_uppercases(self):
+        assert normalize_casename("Hentrich v. France") == "HENTRICH V. FRANCE"

--- a/tests/test_reference_resolver.py
+++ b/tests/test_reference_resolver.py
@@ -13,6 +13,7 @@ from echr_extractor import (
 )
 from echr_extractor.ECHR_nodes_edges_list_transform import (
     MISSING_REFERENCE_COLUMNS,
+    retrieve_edges_list,
 )
 
 HENTRICH_ROW = {
@@ -54,6 +55,32 @@ class TestParseSclReferences:
         assert len(parse_scl_references(None)) == 0
         assert len(parse_scl_references(float("nan"))) == 0
         assert len(parse_scl_references("")) == 0
+
+    def test_parse_matches_network_builder_missing_table(self):
+        """Drift guard: parse_scl_references and the network builder's
+        missing-references table are built from the same shared helpers
+        and must stay row-for-row identical."""
+        scl = (
+            "Nonexistent v. Nowhere, no. 99999/99, 1 January 1999;"
+            "Eur. Court H.R. Ghost v. Void judgment of 27 October 1975"
+        )
+        citing = pd.DataFrame(
+            [
+                {
+                    "itemid": "001-2",
+                    "appno": "100/95",
+                    "docname": "CASE OF AAA v. BELGIUM",
+                    "ecli": "ECLI:CITING",
+                    "languageisocode": "ENG",
+                    "judgementdate": "01/01/2000",
+                    "extractedappno": None,
+                    "scl": scl,
+                }
+            ]
+        )
+        _, missing = retrieve_edges_list(citing, citing)
+        refs = parse_scl_references(scl, citing_id="ECLI:CITING")
+        pd.testing.assert_frame_equal(refs, missing)
 
 
 class TestResolveOffline:
@@ -140,6 +167,122 @@ class TestResolveOffline:
             reference_df=self.reference_df(),
         )
         assert len(resolved) == 0 and len(still) == 1
+
+    def test_old_style_citation_resolves_by_casename(self):
+        """Regression: old-style citations carry 'Eur. Court H.R.' and
+        'judgment of <date>' boilerplate. The resolver used to skip the
+        clean_pattern regexes the network builder applies, so the
+        docname lookup never matched and these stayed unresolved."""
+        refs = parse_scl_references(
+            "Eur. Court H.R. Hentrich v. France judgment of "
+            "22 September 1994, Series A no. 296-A",
+            citing_id="ECLI:CITING",
+        )
+        resolved, _, still = resolve_references(
+            refs, reference_df=self.reference_df()
+        )
+        assert len(still) == 0
+        assert len(resolved) == 1
+        assert resolved.iloc[0]["resolved_id"] == "ECLI:CE:ECHR:1994:HENTRICH"
+        assert resolved.iloc[0]["match_method"] == "casename"
+
+    def test_old_style_citation_with_comma_after_reporter(self):
+        """The 'Eur. Court H.R., <name> judgment of <date>' variant
+        leaves a leading comma behind after boilerplate stripping; it
+        must be trimmed for the docname lookup to match."""
+        refs = parse_scl_references(
+            "Eur. Court H.R., Hentrich v. France judgment of "
+            "22 September 1994, Series A no. 296-A",
+            citing_id="ECLI:CITING",
+        )
+        resolved, _, still = resolve_references(
+            refs, reference_df=self.reference_df()
+        )
+        assert len(still) == 0
+        assert resolved.iloc[0]["resolved_id"] == "ECLI:CE:ECHR:1994:HENTRICH"
+
+    def test_old_style_citation_without_respondent_resolves(self):
+        """Regression: old-style citations that omit the respondent
+        ('Eur. Court H.R. James and Others judgment of ...') contain no
+        'v.' marker and were misclassified as French, so the language
+        filter rejected the English target even after normalization."""
+        belgian_police = dict(
+            HENTRICH_ROW,
+            itemid="001-57435",
+            appno="4464/70",
+            docname="CASE OF NATIONAL UNION OF BELGIAN POLICE v. BELGIUM",
+            ecli="ECLI:CE:ECHR:1975:BELPOLICE",
+            judgementdate="27/10/1975",
+            kpdate="1975-10-27T00:00:00",
+        )
+        refs = parse_scl_references(
+            "Eur. Court H.R. National Union of Belgian Police judgment "
+            "of 27 October 1975, Series A no. 19",
+            citing_id="ECLI:CITING",
+        )
+        assert refs.iloc[0]["ref_language"] == ""
+        resolved, _, still = resolve_references(
+            refs, reference_df=pd.DataFrame([belgian_police])
+        )
+        assert len(still) == 0
+        assert resolved.iloc[0]["resolved_id"] == "ECLI:CE:ECHR:1975:BELPOLICE"
+
+    def test_online_docname_query_uses_normalized_casename(self):
+        """Regression: the online candidate fetch queried HUDOC with the
+        raw casename including 'judgment of' boilerplate, so old-style
+        targets never entered the candidate pool."""
+        refs = parse_scl_references(
+            "Eur. Court H.R. National Union of Belgian Police judgment "
+            "of 27 October 1975, Series A no. 19",
+            citing_id="ECLI:CITING",
+        )
+        with patch(
+            "echr_extractor.ECHR_metadata_harvester.requests.get",
+            return_value=hudoc_response([]),
+        ) as mock_get:
+            resolve_references(refs)
+        url = mock_get.call_args_list[0].args[0]
+        assert "NATIONAL%20UNION%20OF%20BELGIAN%20POLICE" in url
+        assert "JUDGMENT%20OF" not in url
+
+    def test_original_document_preferred_over_translation(self):
+        """When the reference language is unknown, the original ENG/FRE
+        judgment must outrank translation entries (which would otherwise
+        win on itemid order)."""
+        translation = dict(
+            HENTRICH_ROW,
+            itemid="001-00001",  # sorts before the original
+            ecli="ECLI:TRANSLATION",
+            docname="CASE OF HENTRICH v. FRANCE - [Russian Translation]",
+            languageisocode="RUS",
+        )
+        refs = parse_scl_references(
+            "Eur. Court H.R. Hentrich judgment of 22 September 1994",
+            citing_id="ECLI:CITING",
+        )
+        assert refs.iloc[0]["ref_language"] == ""
+        resolved, _, still = resolve_references(
+            refs, reference_df=pd.DataFrame([translation, HENTRICH_ROW])
+        )
+        assert len(still) == 0
+        assert resolved.iloc[0]["resolved_id"] == "ECLI:CE:ECHR:1994:HENTRICH"
+
+    def test_nan_itemid_rows_are_ignored(self):
+        """Regression: reference_df rows with NaN itemids used to
+        stringify to 'nan' and become phantom external nodes."""
+        nan_itemid = dict(HENTRICH_ROW, itemid=float("nan"), ecli="ECLI:NAN")
+        resolved, external, still = resolve_references(
+            self.missing(), reference_df=pd.DataFrame([nan_itemid])
+        )
+        assert len(resolved) == 0 and len(still) == 1
+        assert len(external) == 0
+
+    def test_missing_required_columns_raises(self):
+        malformed = pd.DataFrame(
+            [{"citing_id": "ECLI:CITING", "missing_references": "X v. Y"}]
+        )
+        with pytest.raises(ValueError, match="parse_scl_references"):
+            resolve_references(malformed, reference_df=self.reference_df())
 
     def test_empty_missing_df(self):
         resolved, external, still = resolve_references(


### PR DESCRIPTION
Follow-up to #18, addressing the six findings from the pre-release code review of the reference resolver.

## Changes

- **Shared matching helpers**: the citation-parsing and matching logic duplicated between the network builder and the resolver (scl splitting, reference parsing, casename normalization, word-boundary docname lookup, year derivation, language/year filtering) now lives in shared helpers consumed by both — the enclosed network and external resolution can no longer drift.
- **Old-style citations resolve**: `Eur. Court H.R. X judgment of <date>` references now work end to end. Three separate gaps fixed: the resolver skipped the `clean_pattern` boilerplate stripping; references without a `v.`/`c.` marker were misclassified as French and rejected by the language filter; and the online candidate queries used the raw casename, so the target never entered the candidate pool. Verified live: the 1975 *National Union of Belgian Police* citation resolves to the original judgment.
- **Better match ranking**: original-language judgments are preferred over translation entries.
- **Clear input validation**: `resolve_references` raises a descriptive `ValueError` (pointing at `parse_scl_references`) when required columns are missing, instead of a raw `KeyError`; the column contract is documented.
- **Edge cases**: `start_id` is consumed by a failed first date window rather than silently skipping records of a later window; `reference_df` rows with NaN itemids no longer become phantom `'nan'` nodes; the second online resolution pass indexes only newly fetched candidates.

## Testing

14 new unit tests (339 total pass), 14 live HUDOC tests pass (`pytest --run-live`), flake8 clean.