### PR TITLE
Retry empty HUDOC full-text conversions

### DIFF
--- a/src/echr_extractor/ECHR_html_downloader.py
+++ b/src/echr_extractor/ECHR_html_downloader.py
@@ -105,6 +105,7 @@ def download_full_text_separate(
     retry_attempts=DEFAULT_RETRY_ATTEMPTS,
 ):
     full_list = []
+    empty_by_id = {}
     eclis = eclis.reset_index(drop=True)
     item_ids = item_ids.reset_index(drop=True)
 
@@ -118,13 +119,25 @@ def download_full_text_separate(
                 r = requests.get(base_url + item_id, timeout=timeout)
                 # An error page must not be stored as the document text
                 r.raise_for_status()
+                full_text = get_full_text_from_html(r.text)
                 json_dict = {
                     "item_id": item_id,
                     "ecli": ecli,
-                    "full_text": get_full_text_from_html(r.text),
+                    "full_text": full_text,
                 }
-                full_list.append(json_dict)
+                if full_text:
+                    empty_by_id.pop(item_id, None)
+                    full_list.append(json_dict)
+                else:
+                    # HUDOC's conversion service can temporarily return a
+                    # successful but empty response. Retry it just like a
+                    # transport error, while retaining the empty record if
+                    # every attempt is empty so metadata alignment is kept.
+                    empty_by_id[item_id] = json_dict
+                    retry_ids.append(item_id)
+                    retry_eclis.append(ecli)
             except Exception:
+                empty_by_id.pop(item_id, None)
                 retry_ids.append(item_id)
                 retry_eclis.append(ecli)
         return retry_ids, retry_eclis
@@ -134,14 +147,15 @@ def download_full_text_separate(
         retry_ids, retry_eclis = download_html(retry_ids, retry_eclis)
         if not retry_ids:
             break
-    failed_ids = retry_ids
+    empty_ids = [item_id for item_id in retry_ids if item_id in empty_by_id]
+    failed_ids = [item_id for item_id in retry_ids if item_id not in empty_by_id]
     if failed_ids:
         logging.warning(
             f"Full text could not be downloaded for {len(failed_ids)} "
             f"document(s): {failed_ids}"
         )
-    empty_ids = [d["item_id"] for d in full_list if not d["full_text"]]
     if empty_ids:
+        full_list.extend(empty_by_id[item_id] for item_id in empty_ids)
         logging.warning(
             f"No HTML text available (kept with empty full_text) for "
             f"{len(empty_ids)} document(s): {empty_ids}"

--- a/tests/test_html_downloader.py
+++ b/tests/test_html_downloader.py
@@ -14,8 +14,8 @@ def fake_html_response(status_code, body=""):
     response.status_code = status_code
     response.text = body
     if status_code >= 400:
-        response.raise_for_status.side_effect = (
-            requests_module.exceptions.HTTPError(f"{status_code}")
+        response.raise_for_status.side_effect = requests_module.exceptions.HTTPError(
+            f"{status_code}"
         )
     else:
         response.raise_for_status.return_value = None
@@ -26,9 +26,7 @@ class TestDownloadFullTextMain:
     def test_error_pages_are_not_stored_as_text(self, caplog):
         """A 404/500 body must never end up as a document's full_text;
         permanently failing documents are dropped with a warning."""
-        df = pd.DataFrame(
-            {"itemid": ["001-1", "001-2"], "ecli": ["ECLI:1", "ECLI:2"]}
-        )
+        df = pd.DataFrame({"itemid": ["001-1", "001-2"], "ecli": ["ECLI:1", "ECLI:2"]})
         responses = {
             "001-1": [fake_html_response(200, "<p>Real judgment text</p>")],
             "001-2": [
@@ -74,12 +72,28 @@ class TestDownloadFullTextMain:
         with patch(
             "echr_extractor.ECHR_html_downloader.requests.get",
             return_value=fake_html_response(204, ""),
-        ):
+        ) as get:
             result = download_full_text_main(df, threads=1)
 
         assert len(result) == 1
         assert result[0]["full_text"] == ""
+        assert get.call_count == 2
         assert "No HTML text available" in caplog.text
+
+    def test_empty_conversion_recovers_on_retry(self):
+        df = pd.DataFrame({"itemid": ["001-1"], "ecli": ["ECLI:1"]})
+        responses = [
+            fake_html_response(204, ""),
+            fake_html_response(200, "<p>Available on retry</p>"),
+        ]
+        with patch(
+            "echr_extractor.ECHR_html_downloader.requests.get",
+            side_effect=responses,
+        ):
+            result = download_full_text_main(df, threads=1)
+
+        assert len(result) == 1
+        assert result[0]["full_text"] == "Available on retry"
 
 
 def test_get_full_text_preserves_paragraphs_and_commas():


### PR DESCRIPTION
## What
- retry successful-but-empty HUDOC conversion responses
- preserve the existing metadata-alignment contract by keeping an empty record only after the final empty attempt
- continue dropping persistent HTTP failures rather than storing error pages
- add recovery and persistent-empty regression coverage

## Live evidence
HUDOC metadata confirms item 001-250597 exists, while its HTML and PDF conversion endpoints currently time out. The April-August staging artifacts contain 298 empty bodies; the downloader previously never retried an empty successful response.

## Verification
- PYTHONPATH=src pytest -q tests/test_html_downloader.py (6 passed)
- black --check passes
- full suite collection is blocked by the repository missing tests/fixtures/segmentation_live_samples/manifest.json